### PR TITLE
🧪 [testing improvement description] Add tests for normalize_url in deduplicator

### DIFF
--- a/tests/unit/test_news_phase12.py
+++ b/tests/unit/test_news_phase12.py
@@ -55,6 +55,7 @@ from nexus_scalp.news.ingest import (
     NewsScheduler,
     canonicalize_item,
     normalize_title,
+    normalize_url,
 )
 from nexus_scalp.news.models import (
     CurrentNewsContext,
@@ -244,6 +245,15 @@ class TestDeduplication:
         # lowercase canonical form (case-insensitive identity)
         assert normalize_title("  FED   RAISES  RATES!!! ") == "fed raises rates"
         assert normalize_title("The Fed and the ECB vs markets: update") == "fed ecb markets update"
+
+    def test_11b_normalized_url_strips_noise(self):
+        assert normalize_url("https://www.example.com/article/") == "example.com/article"
+        assert normalize_url("http://example.com/article?utm_source=twitter") == "example.com/article"
+        assert normalize_url("https://example.com/article#comments") == "example.com/article"
+        assert normalize_url("  https://www.example.com/article/?q=1  ") == "example.com/article"
+        assert normalize_url("https://example.com/ARTICLE") == "example.com/article"
+        assert normalize_url(None) == ""
+        assert normalize_url("") == ""
 
     def test_12_updated_article_creates_version_not_overwrite(self, seeded_db):
         engine = NewsEngine(config=NewsConfig(db_path=str(seeded_db.db_path)))


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tests for `normalize_url` in `src/nexus_scalp/news/ingest/deduplicator.py` were missing.

📊 **Coverage:** What scenarios are now tested
- Stripping `http://` and `https://`
- Stripping `www.`
- Stripping trailing slashes
- Stripping query parameters (`?utm_source=twitter`)
- Stripping fragments (`#comments`)
- Lowercasing the output
- Handling `None` and empty strings correctly.

✨ **Result:** The improvement in test coverage
The deduplication URL normalization logic is now thoroughly verified by the test suite, catching potential regressions.

---
*PR created automatically by Jules for task [12889606039882095600](https://jules.google.com/task/12889606039882095600) started by @Opselon*