### PR TITLE
🧪 test: implement news source adapter factory testing

### DIFF
--- a/tests/unit/news/test_news_source_factory.py
+++ b/tests/unit/news/test_news_source_factory.py
@@ -1,0 +1,35 @@
+import pytest
+from src.nexus_scalp.news.sources.base import build_adapter, RSSNewsSourceAdapter, OfficialSourceAdapter
+
+def test_build_adapter_default():
+    config = {}
+    adapter = build_adapter(config)
+    assert isinstance(adapter, RSSNewsSourceAdapter)
+    assert not isinstance(adapter, OfficialSourceAdapter)
+
+def test_build_adapter_rss():
+    config = {"kind": "RSS"}
+    adapter = build_adapter(config)
+    assert isinstance(adapter, RSSNewsSourceAdapter)
+    assert not isinstance(adapter, OfficialSourceAdapter)
+
+def test_build_adapter_official():
+    config = {"kind": "OFFICIAL"}
+    adapter = build_adapter(config)
+    assert isinstance(adapter, OfficialSourceAdapter)
+
+def test_build_adapter_calendar():
+    config = {"kind": "CALENDAR"}
+    adapter = build_adapter(config)
+    assert isinstance(adapter, OfficialSourceAdapter)
+
+def test_build_adapter_case_insensitive():
+    config = {"kind": "official"}
+    adapter = build_adapter(config)
+    assert isinstance(adapter, OfficialSourceAdapter)
+
+def test_build_adapter_unknown():
+    config = {"kind": "UNKNOWN_KIND"}
+    adapter = build_adapter(config)
+    assert isinstance(adapter, RSSNewsSourceAdapter)
+    assert not isinstance(adapter, OfficialSourceAdapter)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested `build_adapter` factory function in `src/nexus_scalp/news/sources/base.py`.
📊 **Coverage:** Test coverage for `build_adapter` is now at 100% via unit tests handling all expected kind mappings, fallbacks, case variations, and unmapped defaults.
✨ **Result:** Increased test suite reliability with explicit tests validating that correct concrete NewsSourceAdapters (`RSSNewsSourceAdapter` and `OfficialSourceAdapter`) are instantiated strictly per configuration dictionary.

---
*PR created automatically by Jules for task [11233258847619971274](https://jules.google.com/task/11233258847619971274) started by @Opselon*