### PR TITLE
🧪 Add unit tests for `provider_status_for_console`

### DIFF
--- a/tests/unit/news/test_pro_auto.py
+++ b/tests/unit/news/test_pro_auto.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from nexus_scalp.news.pro_auto import provider_status_for_console
+from nexus_scalp.news.ai_service import NewsAIStatus, NewsAIStatusState
+
+@patch("nexus_scalp.news.pro_auto.get_ai_status")
+@patch("nexus_scalp.news.pro_auto.resolve_factory_provider")
+def test_provider_status_for_console_success(mock_resolve_provider, mock_get_ai_status):
+    # Setup mocks
+    mock_status = NewsAIStatus(
+        configured=True,
+        available=True,
+        state=NewsAIStatusState.AVAILABLE,
+        provider="test_provider",
+        model="test_model",
+        base_url="https://test.url",
+        source="test_source",
+        detail="OK"
+    )
+    mock_get_ai_status.return_value = mock_status
+
+    mock_provider = MagicMock()
+    mock_provider.available.return_value = True
+    mock_provider.provider_name = "MockedProvider"
+    mock_provider.model = "gpt-4-test"
+    mock_provider.api_base_url = "https://mock.provider.com/v1"
+    mock_resolve_provider.return_value = mock_provider
+
+    # Call function
+    result = provider_status_for_console(engine=None, settings_service=None)
+
+    # Assertions
+    assert result["ai_status"] == mock_status.to_dict()
+    assert result["provider_available"] is True
+    assert result["provider_name"] == "MockedProvider"
+    assert result["model"] == "gpt-4-test"
+    assert result["base_url"] == "https://mock.provider.com/v1"
+
+    mock_get_ai_status.assert_called_once_with(None, None)
+    mock_resolve_provider.assert_called_once_with(None, None)
+
+@patch("nexus_scalp.news.pro_auto.get_ai_status")
+@patch("nexus_scalp.news.pro_auto.resolve_factory_provider")
+def test_provider_status_for_console_no_provider(mock_resolve_provider, mock_get_ai_status):
+    # Setup mocks
+    mock_status = NewsAIStatus(
+        configured=False,
+        available=False,
+        state=NewsAIStatusState.NOT_CONFIGURED,
+    )
+    mock_get_ai_status.return_value = mock_status
+
+    # resolve_factory_provider returns None when provider is not configured
+    mock_resolve_provider.return_value = None
+
+    # Call function
+    result = provider_status_for_console(engine=None, settings_service=None)
+
+    # Assertions
+    assert result["ai_status"] == mock_status.to_dict()
+    assert result["provider_available"] is False
+    assert result["provider_name"] == ""
+    assert result["model"] == ""
+    assert result["base_url"] == ""
+
+    mock_get_ai_status.assert_called_once_with(None, None)
+    mock_resolve_provider.assert_called_once_with(None, None)
+
+@patch("nexus_scalp.news.pro_auto.get_ai_status")
+@patch("nexus_scalp.news.pro_auto.resolve_factory_provider")
+def test_provider_status_for_console_provider_unavailable(mock_resolve_provider, mock_get_ai_status):
+    # Setup mocks
+    mock_status = NewsAIStatus(
+        configured=True,
+        available=False,
+        state=NewsAIStatusState.UNAVAILABLE,
+    )
+    mock_get_ai_status.return_value = mock_status
+
+    mock_provider = MagicMock()
+    mock_provider.available.return_value = False
+    mock_provider.provider_name = "MockedProvider"
+    mock_provider.model = "gpt-4-test"
+    mock_provider.api_base_url = "https://mock.provider.com/v1"
+    mock_resolve_provider.return_value = mock_provider
+
+    # Call function
+    result = provider_status_for_console(engine=None, settings_service=None)
+
+    # Assertions
+    assert result["ai_status"] == mock_status.to_dict()
+    assert result["provider_available"] is False
+    assert result["provider_name"] == "MockedProvider"
+    assert result["model"] == "gpt-4-test"
+    assert result["base_url"] == "https://mock.provider.com/v1"
+
+    mock_get_ai_status.assert_called_once_with(None, None)
+    mock_resolve_provider.assert_called_once_with(None, None)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `provider_status_for_console` function in `src/nexus_scalp/news/pro_auto.py`.
📊 **Coverage:** Covered all three main scenarios for this function:
*   Happy path (configured and available provider).
*   No provider configured (resolution returns `None`).
*   Provider configured but unavailable.
✨ **Result:** The function `provider_status_for_console` now has 100% test coverage, providing confidence when making future changes to the provider initialization sequence.

---
*PR created automatically by Jules for task [5293277447889867576](https://jules.google.com/task/5293277447889867576) started by @Opselon*