### PR TITLE
⚡ Optimize model hot-swap to avoid synchronous blocking using asyncio.to_thread

### DIFF
--- a/src/nexus_scalp/application/live_engine.py
+++ b/src/nexus_scalp/application/live_engine.py
@@ -1099,7 +1099,10 @@ class LiveEngine:
             # the serving bundle). _load_or_create_bundle raises on dimension
             # mismatch and quarantines corrupt checkpoints.
             import asyncio
-            new_bundle = await asyncio.to_thread(self._load_or_create_bundle, model_path=new_path, force_fresh=False)
+
+            new_bundle = await asyncio.to_thread(
+                self._load_or_create_bundle, model_path=new_path, force_fresh=False
+            )
 
             def _warmup_and_hash():
                 # Warm-up: one forward pass validates the artifact end-to-end.

--- a/src/nexus_scalp/application/live_engine.py
+++ b/src/nexus_scalp/application/live_engine.py
@@ -1073,7 +1073,7 @@ class LiveEngine:
         except Exception as e:
             logger.error("[MODEL] provenance registration failed (isolated)", error=str(e))
 
-    def hot_swap_model(self, new_artifact_path: str, *, source: str = "WEB_UI") -> dict:
+    async def hot_swap_model(self, new_artifact_path: str, *, source: str = "WEB_UI") -> dict:
         """Atomically swap the serving model artifact (safe hot swap).
 
         Loads + validates + warms the NEW bundle FIRST; only on success the
@@ -1081,7 +1081,6 @@ class LiveEngine:
         In-flight inference completes against the old bundle under the
         bundle lock. Never replaces a healthy model with an invalid artifact.
         """
-        import hashlib
 
         new_path = Path(new_artifact_path)
         old_path = Path(self.config.model.model_artifact_path)
@@ -1099,22 +1098,29 @@ class LiveEngine:
             # Load + validate the NEW bundle in isolation (never touching
             # the serving bundle). _load_or_create_bundle raises on dimension
             # mismatch and quarantines corrupt checkpoints.
-            new_bundle = self._load_or_create_bundle(model_path=new_path, force_fresh=False)
-            # Warm-up: one forward pass validates the artifact end-to-end.
-            import numpy as np
-            import torch
+            import asyncio
+            new_bundle = await asyncio.to_thread(self._load_or_create_bundle, model_path=new_path, force_fresh=False)
 
-            warm = np.zeros((1, int(new_bundle.model.num_features)), dtype=np.float32)
-            warm = new_bundle.scaler.transform(warm)
-            with torch.inference_mode():
-                new_bundle.model(torch.tensor(warm, dtype=torch.float32))
+            def _warmup_and_hash():
+                # Warm-up: one forward pass validates the artifact end-to-end.
+                import hashlib
 
-            # Compute artifact hash for traceability (model version/hash)
-            h = hashlib.sha256()
-            with open(new_path, "rb") as f:
-                for chunk in iter(lambda: f.read(65536), b""):
-                    h.update(chunk)
-            artifact_hash = h.hexdigest()[:16]
+                import numpy as np
+                import torch
+
+                warm = np.zeros((1, int(new_bundle.model.num_features)), dtype=np.float32)
+                warm = new_bundle.scaler.transform(warm)
+                with torch.inference_mode():
+                    new_bundle.model(torch.tensor(warm, dtype=torch.float32))
+
+                # Compute artifact hash for traceability (model version/hash)
+                h = hashlib.sha256()
+                with open(new_path, "rb") as f:
+                    for chunk in iter(lambda: f.read(65536), b""):
+                        h.update(chunk)
+                return h.hexdigest()[:16]
+
+            artifact_hash = await asyncio.to_thread(_warmup_and_hash)
 
             # ATOMIC SWAP under the bundle lock: new bundle replaces old.
             with self._bundle_lock:

--- a/src/nexus_scalp/web/server.py
+++ b/src/nexus_scalp/web/server.py
@@ -3284,7 +3284,7 @@ def create_app(engine_ref: Any = None) -> FastAPI:
         return out
 
     @app.post("/api/runtime-config/model-swap")
-    def model_hot_swap(payload: dict[str, Any]) -> dict[str, Any]:
+    async def model_hot_swap(payload: dict[str, Any]) -> dict[str, Any]:
         """Model artifact hot swap: load-validate-warm-atomic-swap.
 
         Payload: {"model_artifact_path": "..."}
@@ -3297,7 +3297,7 @@ def create_app(engine_ref: Any = None) -> FastAPI:
         artifact = str(payload.get("model_artifact_path") or "").strip()
         if not artifact:
             raise HTTPException(status_code=422, detail="model_artifact_path required")
-        result = engine.hot_swap_model(artifact, source="WEB_UI")
+        result = await engine.hot_swap_model(artifact, source="WEB_UI")
         return result
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
This pull request resolves an issue where the FastAPI server's thread pool and application event loop could encounter blocking delays during model hot-swapping due to synchronous file I/O and PyTorch inference initializations. 

### Changes
* **`LiveEngine.hot_swap_model`** now operates as an asynchronous method natively.
* The model loading step (`self._load_or_create_bundle`), the PyTorch warm-up step, and the heavy SHA256 file hashing are all successfully offloaded to a background thread using `asyncio.to_thread()`, yielding execution control back to the event loop.
* **`src/nexus_scalp/web/server.py`** has been updated to mark the API endpoint `model_hot_swap` as `async def` and securely `await` the live engine swap.

### Verifications
* Type checks with Mypy pass properly against the updated typings.
* Ruff linting completes successfully.
* Associated critical test suites pass, verifying the system behaves correctly with the asynchronous swap integration.

---
*PR created automatically by Jules for task [16048294162693232197](https://jules.google.com/task/16048294162693232197) started by @Opselon*