### PR TITLE
fix: enforce apply method implementation in database migration templates

### DIFF
--- a/src/nexus_scalp/cli/db_commands.py
+++ b/src/nexus_scalp/cli/db_commands.py
@@ -537,8 +537,7 @@ def _migration_template(domain: str, name: str) -> str:
         f"import sqlite3\n\n\n"
         f"def apply(conn: sqlite3.Connection, db_path: Path) -> None:\n"
         f'    """Apply the schema change (idempotent)."""\n'
-        f"    # TODO: implement\n"
-        f"    pass\n\n\n"
+        f"    raise NotImplementedError\n\n\n"
         f"def verify(conn: sqlite3.Connection, db_path: Path) -> bool:\n"
         f'    """Return True when the change is present."""\n'
         f"    return True\n\n\n"


### PR DESCRIPTION
Fixes an issue where generated database migration templates included a `pass` in the `apply` method. This allowed incomplete or empty migration scripts to execute successfully without performing any schema changes. Replacing this with `raise NotImplementedError` enforces strict implementation requirements on the developers generating the templates.

---
*PR created automatically by Jules for task [8705468705119433963](https://jules.google.com/task/8705468705119433963) started by @Opselon*