### PR TITLE
🧹 refactor: split overly complex _create_intelligence_tables in AuditRepository

### DIFF
--- a/src/nexus_scalp/adapters/database/audit_repository.py
+++ b/src/nexus_scalp/adapters/database/audit_repository.py
@@ -726,6 +726,15 @@ class AuditRepository:
             crash mid-cycle resumes from the last checkpoint instead of redoing
             history.
         """
+        self._create_table_position_lifecycle_events(conn)
+        self._create_table_trade_autopsies(conn)
+        self._create_table_behavior_detections(conn)
+        self._create_table_behavior_analysis(conn)
+        self._create_table_strategy_evolution_candidates(conn)
+        self._create_table_intelligence_worker_state(conn)
+        self._create_factory_tables(conn)
+
+    def _create_table_position_lifecycle_events(self, conn: sqlite3.Connection) -> None:
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS position_lifecycle_events (
@@ -756,6 +765,16 @@ class AuditRepository:
             except Exception:
                 pass
 
+        for index_sql in (
+            "CREATE INDEX IF NOT EXISTS idx_lifecycle_ticket ON position_lifecycle_events(ticket, sequence);",
+            "CREATE INDEX IF NOT EXISTS idx_lifecycle_type ON position_lifecycle_events(event_type);",
+        ):
+            try:
+                conn.execute(index_sql)
+            except Exception:
+                pass
+
+    def _create_table_trade_autopsies(self, conn: sqlite3.Connection) -> None:
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS trade_autopsies (
@@ -801,6 +820,14 @@ class AuditRepository:
             except Exception:
                 pass
 
+        try:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_autopsy_strategy ON trade_autopsies(strategy_id);"
+            )
+        except Exception:
+            pass
+
+    def _create_table_behavior_detections(self, conn: sqlite3.Connection) -> None:
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS behavior_detections (
@@ -828,6 +855,16 @@ class AuditRepository:
             except Exception:
                 pass
 
+        for index_sql in (
+            "CREATE INDEX IF NOT EXISTS idx_behavior_ticket ON behavior_detections(ticket);",
+            "CREATE INDEX IF NOT EXISTS idx_behavior_pattern ON behavior_detections(pattern);",
+        ):
+            try:
+                conn.execute(index_sql)
+            except Exception:
+                pass
+
+    def _create_table_behavior_analysis(self, conn: sqlite3.Connection) -> None:
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS behavior_analysis (
@@ -886,6 +923,7 @@ class AuditRepository:
             except Exception:
                 pass
 
+    def _create_table_strategy_evolution_candidates(self, conn: sqlite3.Connection) -> None:
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS strategy_evolution_candidates (
@@ -905,7 +943,14 @@ class AuditRepository:
             );
             """
         )
+        try:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_evolution_status ON strategy_evolution_candidates(status);"
+            )
+        except Exception:
+            pass
 
+    def _create_table_intelligence_worker_state(self, conn: sqlite3.Connection) -> None:
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS intelligence_worker_state (
@@ -917,6 +962,8 @@ class AuditRepository:
             );
             """
         )
+
+    def _create_factory_tables(self, conn: sqlite3.Connection) -> None:
         # =====================================================================
         # STRATEGY FACTORY research memory (2026-08-20) — append-only records.
         # The factory ORCHESTRATES generation/evolution over the research
@@ -1049,22 +1096,6 @@ class AuditRepository:
             )
         except Exception:
             pass
-
-        for index_sql in (
-            "CREATE INDEX IF NOT EXISTS idx_lifecycle_ticket "
-            "ON position_lifecycle_events(ticket, sequence);",
-            "CREATE INDEX IF NOT EXISTS idx_lifecycle_type "
-            "ON position_lifecycle_events(event_type);",
-            "CREATE INDEX IF NOT EXISTS idx_autopsy_strategy ON trade_autopsies(strategy_id);",
-            "CREATE INDEX IF NOT EXISTS idx_behavior_ticket ON behavior_detections(ticket);",
-            "CREATE INDEX IF NOT EXISTS idx_behavior_pattern ON behavior_detections(pattern);",
-            "CREATE INDEX IF NOT EXISTS idx_evolution_status "
-            "ON strategy_evolution_candidates(status);",
-        ):
-            try:
-                conn.execute(index_sql)
-            except Exception:
-                pass
 
     def _create_research_tables(self, conn: sqlite3.Connection) -> None:
         """


### PR DESCRIPTION
🎯 **What:** Extracted the excessively long `_create_intelligence_tables` method in `AuditRepository` into multiple smaller, semantic helper functions (e.g. `_create_table_trade_autopsies`, `_create_factory_tables`). 
💡 **Why:** This improves readability, maintainability, and encapsulation by grouping `CREATE TABLE`, `ALTER TABLE` fallbacks, and `CREATE INDEX` logic per distinct database schema entity, resolving the code health issue.
✅ **Verification:** Verified that linting (ruff check), formatting (ruff format), static analysis (mypy), unit tests (`test_audit_db_growth_bug054.py`), and integration tests (`test_database_execution_audit.py`) pass without issue, confirming equivalent functionality without introducing regressions.
✨ **Result:** Clean, modularized SQLite schema initialization inside `AuditRepository`.

---
*PR created automatically by Jules for task [1367802584926542668](https://jules.google.com/task/1367802584926542668) started by @Opselon*