### PR TITLE
🧹 Remove unused import ctypes in diagnostics runner

### DIFF
--- a/src/nexus_scalp/diagnostics/runner.py
+++ b/src/nexus_scalp/diagnostics/runner.py
@@ -37,8 +37,6 @@ def _kill_tree(proc: subprocess.Popen[bytes]) -> None:
         if sys.platform.startswith("win"):
             # taskkill reliably kills the tree on Windows.
             try:
-                import ctypes  # noqa: F401
-
                 subprocess.run(
                     ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
                     stdout=subprocess.DEVNULL,


### PR DESCRIPTION
🎯 **What:** Removed unused `import ctypes` in `src/nexus_scalp/diagnostics/runner.py`.
💡 **Why:** Cleans up dead code, improving code health and readability. The import was even marked with `# noqa: F401` previously.
✅ **Verification:** Verified by running `ruff check` and `mypy`, which passed cleanly.
✨ **Result:** A slightly cleaner codebase with zero functional changes.

---
*PR created automatically by Jules for task [8884694817980635562](https://jules.google.com/task/8884694817980635562) started by @Opselon*