### PR TITLE
🧹 Code Health: Remove unused urllib.parse import from remote_gateway.py

### DIFF
--- a/src/nexus_scalp/adapters/mt5/remote_gateway.py
+++ b/src/nexus_scalp/adapters/mt5/remote_gateway.py
@@ -15,7 +15,6 @@ import hashlib
 import hmac
 import json
 import time
-import urllib.parse
 import urllib.request
 from datetime import UTC, datetime
 from typing import Any


### PR DESCRIPTION
🎯 **What:** Removed unused `import urllib.parse` from `src/nexus_scalp/adapters/mt5/remote_gateway.py`.
💡 **Why:** The import is never accessed, making it dead code. Removing it improves file readability and slightly speeds up import parsing time, adhering to clean code practices.
✅ **Verification:** Verified via `ruff check` and `mypy` that static analysis passes cleanly without the import. Also confirmed through code inspection that no part of the file uses `urllib.parse`.
✨ **Result:** A cleaner, more maintainable file with no unused imports.

---
*PR created automatically by Jules for task [13517039417528250447](https://jules.google.com/task/13517039417528250447) started by @Opselon*