### PR TITLE
🧹 Remove unused urllib.parse import

### DIFF
--- a/src/nexus_scalp/adapters/mt5/remote_gateway.py
+++ b/src/nexus_scalp/adapters/mt5/remote_gateway.py
@@ -15,7 +15,6 @@ import hashlib
 import hmac
 import json
 import time
-import urllib.parse
 import urllib.request
 from datetime import UTC, datetime
 from typing import Any


### PR DESCRIPTION
🎯 **What:** Removed unused `urllib.parse` import from `src/nexus_scalp/adapters/mt5/remote_gateway.py`.
💡 **Why:** Improves code cleanliness and maintainability by removing unused imports.
✅ **Verification:** Ran `ruff check src/nexus_scalp/adapters/mt5/remote_gateway.py` and `pytest tests/unit/test_accounting_pnl_regression.py` successfully. 
✨ **Result:** A single line of unused import is removed safely.

---
*PR created automatically by Jules for task [4807229210535208901](https://jules.google.com/task/4807229210535208901) started by @Opselon*