### PR TITLE
🧹 Remove unused torch imports in debug_snapshot.py

### DIFF
--- a/src/nexus_scalp/web/debug_snapshot.py
+++ b/src/nexus_scalp/web/debug_snapshot.py
@@ -470,7 +470,6 @@ def _contract_section(engine: Any) -> dict[str, Any]:
             bundle = None
         if bundle is not None:
             try:
-                import torch  # noqa: F401
 
                 model = bundle.model
                 out_shape = None
@@ -541,7 +540,6 @@ def _model_section(engine: Any) -> dict[str, Any]:
             out["reason"] = "NO_MODEL_BUNDLE"
             return out
         import numpy as np
-        import torch  # noqa: F401
 
         scaler_ready = bool(getattr(bundle.scaler, "is_ready", lambda: False)())
         model = bundle.model


### PR DESCRIPTION
🎯 **What:** Removed the unused `import torch` statements from `src/nexus_scalp/web/debug_snapshot.py` at lines 473 and 544.
💡 **Why:** The imports were explicitly marked as unused with `# noqa: F401` and removing them improves code cleanliness, readability, and prevents unnecessary dependencies from being pulled into the scope.
✅ **Verification:** Verified the removal is safe as static analysis guarantees they are never accessed. Ran `pytest tests/unit/test_debug_snapshot_phase20.py` which passed successfully, confirming no functionality is broken.
✨ **Result:** Improved code health by removing dead code.

---
*PR created automatically by Jules for task [17319984841753798152](https://jules.google.com/task/17319984841753798152) started by @Opselon*