### PR TITLE
🧹 Remove unused FailureReason import

### DIFF
--- a/src/nexus_scalp/strategies/factory/summarizer.py
+++ b/src/nexus_scalp/strategies/factory/summarizer.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from typing import Any
 
 from nexus_scalp.strategies.factory.models import (
-    FailureReason,
     GenerationSummary,
     StrategyFamily,
 )
@@ -258,7 +257,6 @@ def format_summary_for_prompt(memory: dict[str, Any]) -> str:
 
 
 __all__ = [
-    "FailureReason",
     "GenerationSummary",
     "StrategyFamily",
     "build_summary",


### PR DESCRIPTION
🎯 **What:** Removed unused `FailureReason` import from `src/nexus_scalp/strategies/factory/summarizer.py` and its corresponding entry in `__all__`.
💡 **Why:** The import was never used in the file, so removing it cleans up the code and resolves static analysis warnings.
✅ **Verification:** Ran pytest tests successfully, and received a #Correct# code review confirming safety and completeness.
✨ **Result:** Improved maintainability and cleaner code structure with no functional changes.

---
*PR created automatically by Jules for task [3064018140613439796](https://jules.google.com/task/3064018140613439796) started by @Opselon*