### PR TITLE
🧪 test: add test coverage for _is_long normalization helper

### DIFF
--- a/tests/unit/test_accounting_normalize.py
+++ b/tests/unit/test_accounting_normalize.py
@@ -1,0 +1,26 @@
+import pytest
+from nexus_scalp.accounting.normalize import _is_long
+
+def test_is_long():
+    """Test that _is_long correctly identifies long direction strings."""
+    # True cases
+    assert _is_long("BUY") is True
+    assert _is_long("buy") is True
+    assert _is_long("Buy") is True
+    assert _is_long("BUY_LIMIT") is True
+    assert _is_long("buy_stop") is True
+    assert _is_long("LONG") is True
+    assert _is_long("long") is True
+    assert _is_long("0") is True
+
+    # False cases
+    assert _is_long("SELL") is False
+    assert _is_long("sell") is False
+    assert _is_long("Sell") is False
+    assert _is_long("SELL_LIMIT") is False
+    assert _is_long("sell_stop") is False
+    assert _is_long("SHORT") is False
+    assert _is_long("short") is False
+    assert _is_long("1") is False
+    assert _is_long("UNKNOWN") is False
+    assert _is_long("") is False


### PR DESCRIPTION
🎯 **What:** The testing gap for the simple `_is_long` function in `src/nexus_scalp/accounting/normalize.py` has been addressed.
📊 **Coverage:** Evaluated all expected standard direction values for MetaTrader compatibility: true scenarios ("BUY", "LONG", "0", including lowercase and limit suffix checks) and false scenarios ("SELL", "SHORT", "1", etc.) and empty strings.
✨ **Result:** Test coverage improved for trade directional parsing ensuring correct PnL and exit normalization later down the pipeline.

---
*PR created automatically by Jules for task [7992343190546664883](https://jules.google.com/task/7992343190546664883) started by @Opselon*