### PR TITLE
🧪 [testing improvement description] Add tests for PeriodBounds SQL formatting properties

### DIFF
--- a/tests/unit/test_accounting_core.py
+++ b/tests/unit/test_accounting_core.py
@@ -333,6 +333,11 @@ class TestPeriodBounds:
         shifted = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone(timedelta(hours=3)))
         assert ensure_utc(shifted).hour == 9
 
+    def test_period_bounds_sql_properties(self) -> None:
+        b = period_bounds(PeriodKind.DAY, datetime(2026, 8, 15, 14, 30, 0, tzinfo=UTC))
+        assert b.start_sql == "2026-08-15 00:00:00"
+        assert b.end_sql == "2026-08-16 00:00:00"
+
 
 from datetime import timezone  # noqa: E402
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `start_sql` and `end_sql` string formatting properties of the `PeriodBounds` class in `src/nexus_scalp/accounting/periods.py`.
📊 **Coverage:** The new test covers the happy path of `start_sql` and `end_sql` properties returning correct, SQLite-compatible string representations of boundaries (inclusive start, exclusive end).
✨ **Result:** Increased unit test coverage and confidence in the accounting subsystem's interaction with the SQLite database via proper timestamp formatting.

---
*PR created automatically by Jules for task [17160292617619339153](https://jules.google.com/task/17160292617619339153) started by @Opselon*