### PR TITLE
🧪 [testing] Improve error handling coverage for parse_sql_timestamp

### DIFF
--- a/tests/unit/test_accounting_core.py
+++ b/tests/unit/test_accounting_core.py
@@ -326,8 +326,14 @@ class TestPeriodBounds:
         assert parse_sql_timestamp("2026-08-15 10:00:00").hour == 10
         assert parse_sql_timestamp("2026-08-15T10:00:00+00:00").hour == 10
         assert parse_sql_timestamp("2026-08-15T10:00:00Z").hour == 10
+        assert parse_sql_timestamp("2026-08-15").hour == 0
+        assert parse_sql_timestamp("2026-08-15").day == 15
+        assert parse_sql_timestamp("2026-08-15 10:00:00.123456").microsecond == 123456
         assert parse_sql_timestamp(None) is None
+        assert parse_sql_timestamp("") is None
+        assert parse_sql_timestamp("   ") is None
         assert parse_sql_timestamp("garbage") is None
+        assert parse_sql_timestamp("2026-13-45") is None
 
     def test_ensure_utc_converts_offsets(self) -> None:
         shifted = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone(timedelta(hours=3)))


### PR DESCRIPTION
🎯 **What:** The testing gap in `parse_sql_timestamp` error handling was addressed. The function accepts stored strings in several shapes, and returns `None` for unparseable input. Prior to this, whitespace-only inputs, empty inputs, and completely broken date inputs were not rigorously asserted in tests, leaving branch paths uncovered.
📊 **Coverage:** Additional validation assertions for empty strings (`""`), whitespace-only strings (`"   "`), nonexistent dates (`"2026-13-45"`), partial strings, and edge-case valid inputs (fractional microseconds, date-only without timestamp) were introduced. All branches inside `parse_sql_timestamp` are now covered.
✨ **Result:** Test coverage for `src/nexus_scalp/accounting/periods.py` is increased, particularly for line 193, ensuring robust failure tolerance without throwing exceptions for bad datetimes.

---
*PR created automatically by Jules for task [3113940449809511050](https://jules.google.com/task/3113940449809511050) started by @Opselon*