### PR TITLE
🧪 add tests for _round_opt helper

### DIFF
--- a/tests/unit/test_accounting_core.py
+++ b/tests/unit/test_accounting_core.py
@@ -36,7 +36,7 @@ from nexus_scalp.accounting import (
     TradeOutcome,
 )
 from nexus_scalp.accounting.aggregation import _usd_per_point, compute_drawdown
-from nexus_scalp.accounting.models import AccountSnapshot, TradeRecord
+from nexus_scalp.accounting.models import AccountSnapshot, TradeRecord, _round_opt
 from nexus_scalp.accounting.normalize import classify_exit, classify_outcome, normalize_trade_row
 from nexus_scalp.accounting.periods import (
     ensure_utc,
@@ -1605,3 +1605,29 @@ class TestForensicQualityJoin:
         assert "NO_EXPERIENCE_LINK" in trace.notes, trace.notes
         assert trace.quality == {}
         assert trace.identity["strategy_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# 12. Helper Functions
+# ---------------------------------------------------------------------------
+
+
+class TestRoundOpt:
+    def test_none_returns_none(self) -> None:
+        assert _round_opt(None) is None
+
+    def test_rounds_to_two_digits_by_default(self) -> None:
+        assert _round_opt(3.14159) == 3.14
+        assert _round_opt(3.145) == 3.15  # Python 3 round behavior, could be 3.14 or 3.15 depending on float representation
+        assert _round_opt(3.1) == 3.1
+        assert _round_opt(3) == 3.0
+
+    def test_rounds_to_specified_digits(self) -> None:
+        assert _round_opt(3.14159, digits=3) == 3.142
+        assert _round_opt(3.14159, digits=0) == 3.0
+        assert _round_opt(3.14159, digits=4) == 3.1416
+
+    def test_handles_negative_and_zero(self) -> None:
+        assert _round_opt(-2.718) == -2.72
+        assert _round_opt(0.0) == 0.0
+        assert _round_opt(0) == 0.0


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The standalone helper function `_round_opt` in `src/nexus_scalp/accounting/models.py` lacked unit tests.

📊 **Coverage:** What scenarios are now tested
- Validates that `None` returns `None`.
- Tests rounding to default 2 decimal places.
- Tests rounding to specified arbitrary number of digits.
- Tests handling of edge cases such as negative numbers and zero.

✨ **Result:** The improvement in test coverage
Increased test coverage for `nexus_scalp.accounting.models` by fully covering the `_round_opt` function in `tests/unit/test_accounting_core.py`. Tests have been verified to pass and successfully fail when logic in the function is intentionally broken.

---
*PR created automatically by Jules for task [4986856907627132495](https://jules.google.com/task/4986856907627132495) started by @Opselon*