### PR TITLE
🧹 Remove unused GenerationMode import from orchestrator.py

### DIFF
--- a/src/nexus_scalp/strategies/factory/orchestrator.py
+++ b/src/nexus_scalp/strategies/factory/orchestrator.py
@@ -58,7 +58,6 @@ from nexus_scalp.strategies.factory.models import (
     FactoryCandidate,
     FactoryStage,
     FailureReason,
-    GenerationMode,
     LoopState,
     StrategyFamily,
 )
@@ -1766,7 +1765,6 @@ MAX_GENERATIONS_READ = 1000
 
 __all__ = [
     "EvolutionConfig",
-    "GenerationMode",
     "LoopState",
     "StrategyFactory",
 ]


### PR DESCRIPTION
🎯 **What:** Removed unused `GenerationMode` import from `src/nexus_scalp/strategies/factory/orchestrator.py` as it was never accessed. Also removed it from the `__all__` list to prevent static analysis errors.
💡 **Why:** The codebase maintainability is improved by reducing unused and dead code, resolving static analysis issues and warnings.
✅ **Verification:** Verified by running the local validation script (`beforePush.sh`) which runs Ruff for linting, Mypy for static type verification, and Pytest to ensure no test cases fail due to this change. Code review approved the changes.
✨ **Result:** The codebase is cleaner and the dead import is resolved.

---
*PR created automatically by Jules for task [16081642243027936144](https://jules.google.com/task/16081642243027936144) started by @Opselon*