### PR TITLE
🧹 Fix unused sqlite3 import in candle_intelligence store

### DIFF
--- a/src/nexus_scalp/candle_intelligence/store.py
+++ b/src/nexus_scalp/candle_intelligence/store.py
@@ -350,8 +350,6 @@ class CandleIntelStore:
         file, WAL allows concurrent access)."""
         # Self-heal corrupted DB (candle_intel.db with bare candles(id) table) — see commit fde756b fix
         try:
-            import sqlite3 as _sqlite3  # noqa: F401
-
             probe_cur = (
                 self._conn.cursor() if hasattr(self, "_conn") and self._conn is not None else None
             )


### PR DESCRIPTION
🎯 **What:** Removed unused import `sqlite3 as _sqlite3` from `src/nexus_scalp/candle_intelligence/store.py`.
💡 **Why:** This improves maintainability and cleans up dead code. Static analysis guarantees the import was unused (`# noqa: F401` was already in place).
✅ **Verification:** Ran pytest tests including `test_strategy_factory_discovery_phase25.py` and standard tests, ensuring no regression. The code review confirmed the removal is completely safe. 
✨ **Result:** A cleaner persistence module schema initialization method.

---
*PR created automatically by Jules for task [18123004935385777341](https://jules.google.com/task/18123004935385777341) started by @Opselon*