### PR TITLE
fix: resolve CSS specificity conflict blocking pointer events on Dependency route

### DIFF
--- a/Web/dependency.html
+++ b/Web/dependency.html
@@ -239,6 +239,10 @@
     justify-content:center; 
     z-index:900; 
   }
+
+  .nx-loading-overlay.hidden {
+    display: none;
+  }
   
   .nx-loading-spinner { 
     width:32px; 


### PR DESCRIPTION
Resolves a CSS specificity conflict on the `/Dependency` route where the `.nx-loading-overlay` was visually hidden due to matching background colors but remained physically rendered (`display: flex;`) and intercepted pointer events (`z-index: 900`).

The fix adds `.nx-loading-overlay.hidden { display: none; }` to `Web/dependency.html`, elevating the specificity above `.nx-loading-overlay { display: flex; }` without relying on `!important` or Javascript modifications.

---
*PR created automatically by Jules for task [13763160712485335827](https://jules.google.com/task/13763160712485335827) started by @Opselon*