### PR TITLE
Fix missing NSE_VERSION environment variable in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,7 @@ jobs:
       - name: Checksums + manifest + SBOM
         shell: pwsh
         run: |
+          $V = $env:NSE_VERSION
           $Out = $env:NSE_OUT
 
           New-Item -ItemType Directory -Force -Path "$Out\checksums" | Out-Null


### PR DESCRIPTION
Adds `$V = $env:NSE_VERSION` in the "Checksums + manifest + SBOM" step in `.github/workflows/release.yml` so that `$V` evaluates correctly and allows the workflow to find the generated artifact instead of creating a double dash in the expected file path.

---
*PR created automatically by Jules for task [3716231726099007401](https://jules.google.com/task/3716231726099007401) started by @Opselon*