### PR TITLE
fix(persistence): reland boot-trust wiring into LiveEngine + fix BUG-140 fixture (CI red)

### DIFF
--- a/src/nexus_scalp/application/live_engine.py
+++ b/src/nexus_scalp/application/live_engine.py
@@ -37,7 +37,10 @@ import polars as pl
 import torch
 
 from nexus_scalp.accounting import AccountingCore, AccountingWorker
-from nexus_scalp.adapters.database.audit_repository import AuditRepository
+from nexus_scalp.adapters.database.audit_repository import (
+    AuditRepository,
+    RuntimeRiskStateReadError,
+)
 from nexus_scalp.candle_intelligence import CandleIntelligenceEngine
 
 # RUNTIME CONFIGURATION (hot reload): the authoritative runtime provider.
@@ -4163,9 +4166,17 @@ class LiveEngine:
         Called at the very start of run_loop. Never recalculates drawdown —
         only the persisted decision decides.
         """
-        decision = resolve_boot_decision(
-            PersistedRiskState.from_row(self.audit.get_runtime_risk_state())
-        )
+        try:
+            row = self.audit.get_runtime_risk_state()
+        except RuntimeRiskStateReadError as err:
+            logger.critical("[SAFETY_STATE] persisted state READ FAILED — failing CLOSED (%s)", err)
+            decision = BootDecision(
+                trading_allowed=False,
+                state="DB_READ_UNCERTAIN",
+                detail=f"PERSISTED_STATE_READ_FAILED: {err}",
+            )
+        else:
+            decision = resolve_boot_decision(PersistedRiskState.from_row(row))
         self._apply_persisted_halt(decision)
         if decision.state == "RUNNING":
             # Mirror the RUNNING decision back durably (single canonical row,

--- a/tests/unit/test_outcome_recovery_sweep_bug140.py
+++ b/tests/unit/test_outcome_recovery_sweep_bug140.py
@@ -132,8 +132,11 @@ def seed_dispatch(
            (ticket, order_id, symbol, action, price, stop_loss, take_profit,
             volume, reason, latency, execution_mode, execution_id, timestamp)
            VALUES (?, ?, ?, 'BUY', ?, 1990.0, 2020.0, 0.1, 'dispatch', 0.01,
-                   'STANDARD', 'EXEC-1', ?)""",
-        (ticket, request_id, symbol, price, ts.isoformat()),
+                   'STANDARD', ?, ?)""",
+        # Agent-17 idempotency contract: execution_id is a UNIQUE identity per
+        # order row (idx_orders_execution_idempotency). Each dispatched order
+        # gets its own execution id derived from the request id.
+        (ticket, request_id, symbol, price, f"EXEC-{request_id}", ts.isoformat()),
     )
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Context (coordinator verification, CI #1065 root-cause)

Origin/main currently has **two persistence-integrity regressions**, both traced to the fleet absorption event `2fc1d84c` + containment revert `f3f53f69`:

1. **Agent-17 P0 boot-trust wiring is HALF-landed.** `c2662e31` (audit_repository: `RuntimeRiskStateReadError`, CLI UNCERTAIN panel) is on origin, but the `LiveEngine._restore_runtime_risk_state` half existed only inside the absorbed `2fc1d84c` and was removed by the `f3f53f69` revert. Net state: the read **raises** but the boot call site **does not catch** — a corrupt/locked audit DB crashes the boot path instead of resolving to the fail-closed `DB_READ_UNCERTAIN` halt. The pinned test `tests/unit/test_persistence_boot_trust.py::test_read_failure_fails_closed_not_open` is RED on origin (reproduced on a pristine origin worktree).

2. **CI #1065 pytest red**: `tests/unit/test_outcome_recovery_sweep_bug140.py::test_expired_and_rejected_states` — `sqlite3.IntegrityError: UNIQUE constraint failed: audit_orders.execution_id`. The BUG-140 fixture reuses the literal `EXEC-1` across order rows, colliding with Agent-17's new `idx_orders_execution_idempotency` UNIQUE index. Test-side fixture fix; production index untouched.

## Changes
- `LiveEngine._restore_runtime_risk_state`: resolve `RuntimeRiskStateReadError` to a fail-closed `DB_READ_UNCERTAIN` `BootDecision` (engine idles; operator must restore DB readability). Parity with the landed CLI panel in `cli/risk_commands.py`.
- BUG-140 fixture: `execution_id` now derived per order (`EXEC-<request_id>`), honoring the idempotency contract.

## Evidence
- Both failures reproduced on a pristine `origin/main` worktree before patching.
- Battery after fix: **67 passed** (test_persistence_boot_trust 4, test_persistence_durability_guarantees 5, test_runtime_safety_mission, test_outcome_recovery_sweep_bug140 12, test_audit_flush_contract, test_dead_letter_store_split, test_outcome_flush_race_bug140).
- `ruff check` + `ruff format --check` clean on both touched files; mypy clean on live_engine.
- Importable-module smoke: `LiveEngine._restore_runtime_risk_state` contains the `DB_READ_UNCERTAIN` branch.

Parallel-safety: only the 2 files above; no foreign WIP touched; no thresholds/gates changed.
