### PR TITLE
QA: restore liq60d audit helpers after scratch/ purge (TASK4-SCRATCH-PROBES) + fix test_41 stale 0.20 pin

### DIFF
--- a/docs/agent_handoffs/swarm/2026-09-11_task4_liq_helpers_restore.md
+++ b/docs/agent_handoffs/swarm/2026-09-11_task4_liq_helpers_restore.md
@@ -1,0 +1,11 @@
+# TASK4-SCRATCH-PROBES restore — companion docs note (pr #122)
+
+Swarm QA cycle 2026-09-11 03:40Z: restored tests/helpers/liq60d_{distribution,redundancy}_audit.py
+(orphaned when a77f8315 deleted scratch/ while test_70d_model_validation_task4.py:749/772 still
+path-loaded them — CI-only FileNotFoundError) and repointed the two loads. Also re-pinned
+test_experience_intelligence.py test_41 to the canonical ModelConfig.confidence_threshold=0.35
+(config.py:79; stale 0.20 pin, red on every CI run of the file).
+
+Evidence: local slim-venv repro RED at d96760be (0.35!=0.20 + 2x FileNotFoundError); after fix
+72 passed, 16 artifact-gated skips; ruff check/format clean; mypy src clean (580 files).
+PR: #122 (branch swarm/task4-liq-helpers, commit fda4a27e).

--- a/tests/helpers/liq60d_distribution_audit.py
+++ b/tests/helpers/liq60d_distribution_audit.py
@@ -1,0 +1,186 @@
+"""TASK-04-70D-MODEL-VALIDATION — Liquidity feature distribution audit (brief 8).
+
+Executable TODAY (no 70D dataset required): computes the 10 Liquidity
+features across deterministic market regimes (trending, ranging, volatility
+bursts, sweep events) using the TASK-01 engine + fixtures, then reports the
+full distribution audit: min/max/mean/median/std/p01..p99, zero_rate,
+missing_rate, unique_count, constant/near-constant/saturated_at_+/-3.
+
+Purpose: determine whether the features are technically correct AND
+scientifically usable (a feature that is 95% zeros or pinned at +3 is
+technically correct but useless).
+
+Regimes (deterministic, from liquidity_fixtures):
+  - TRENDING_UP:     ramp up + swing high
+  - TRENDING_DOWN:   ramp down + swing low
+  - RANGING:         steady flat
+  - VOLATILE:        swing high + swing low sequence (wide ATR)
+  - SWEEP:           stop-hunt (spike through a level then reverse)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+
+import numpy as np
+
+from nexus_scalp.features.liquidity_engine import (
+    LIQUIDITY_FEATURE_NAMES,
+    compute_liquidity_features,
+)
+from tests.helpers.liquidity_fixtures import (
+    bar,
+    steady_bars,
+    swing_high_bars,
+    swing_low_bars,
+)
+
+
+def _sweep_bars() -> list:
+    """Stop-hunt: ramp up to a level, spike THROUGH it (sweep), reverse down."""
+    rng = np.random.default_rng(42)
+    t0 = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    bars = []
+    price = 3300.0
+    for i in range(70):
+        drift = 0.08 if i < 45 else -0.12
+        o = price
+        c = o + drift + float(rng.normal(0, 0.02))
+        h = max(o, c) + 0.15
+        l = min(o, c) - 0.15
+        if i == 55:  # the sweep: spike 2.5x ATR above the recent high
+            h = max(h, 3350.0)
+            c = 3348.0
+        bars.append(bar(i, t0, o, h, l, c, vol=150 if i != 55 else 600))
+        price = c
+    return bars
+
+
+def _volatile_bars() -> list:
+    """Wide-swing alternating highs/lows (wide ATR regime)."""
+    t0 = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    bars = []
+    base = 3300.0
+    for i in range(90):
+        o = base
+        up = i % 2 == 0
+        c = base + (0.4 if up else -0.4)
+        h = max(o, c) + 0.6
+        l = min(o, c) - 0.6
+        bars.append(bar(i, t0, o, h, l, c, vol=300))
+        base = c
+    return bars
+
+
+def _linspace_bars(seed: int = 1) -> list:
+    """Random-walk across many regimes (for percentile coverage)."""
+    rng = np.random.default_rng(seed)
+    t0 = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    bars = []
+    price = 3300.0
+    for i in range(400):
+        o = price
+        c = o + float(rng.normal(0, 0.15))
+        h = max(o, c) + abs(float(rng.normal(0, 0.2)))
+        l = min(o, c) - abs(float(rng.normal(0, 0.2)))
+        bars.append(bar(i, t0, o, h, l, c, vol=int(rng.integers(80, 400))))
+        price = c
+    return bars
+
+
+def main() -> dict:
+    regimes = {
+        "TRENDING_UP": swing_high_bars(60, 3350.0, 3300.0),
+        "TRENDING_DOWN": swing_low_bars(60, 3250.0, 3300.0),
+        "RANGING": steady_bars(100),
+        "VOLATILE": _volatile_bars(),
+        "SWEEP": _sweep_bars(),
+        "RANDOM_WALK": _linspace_bars(),
+    }
+    per_regime: dict[str, list[list[float]]] = {}
+    for name, bars in regimes.items():
+        # slide the window across the series to get many vectors per regime
+        vecs = []
+        for start in range(0, max(len(bars) - 55, 1), 5):
+            win = bars[start : start + 56]
+            if len(win) < 56:
+                continue
+            try:
+                f = compute_liquidity_features(
+                    win,
+                    decision_at=win[-1].timestamp,
+                    mid_price=float(win[-1].close),
+                )
+                v = np.asarray(f.as_vector(), dtype=float)
+                vecs.append(v)
+            except Exception as exc:  # pragma: no cover - engine contract
+                print(f"  [{name}] engine error: {exc}", file=sys.stderr)
+        per_regime[name] = [v.tolist() for v in vecs]
+
+    all_v = np.vstack([np.asarray(v) for vs in per_regime.values() for v in vs])
+    report: dict[str, dict] = {}
+    for j, fname in enumerate(LIQUIDITY_FEATURE_NAMES):
+        col = all_v[:, j]
+        finite = np.isfinite(col)
+        nonzero = col[finite] != 0.0
+        pcts = np.percentile(col[finite], [1, 5, 25, 50, 75, 95, 99]) if finite.any() else [0] * 7
+        report[fname] = {
+            "min": round(float(col[finite].min()), 4) if finite.any() else None,
+            "max": round(float(col[finite].max()), 4) if finite.any() else None,
+            "mean": round(float(col[finite].mean()), 4) if finite.any() else None,
+            "median": round(float(np.median(col[finite])), 4) if finite.any() else None,
+            "std": round(float(col[finite].std()), 4) if finite.any() else None,
+            "p01": round(float(pcts[0]), 4),
+            "p05": round(float(pcts[1]), 4),
+            "p25": round(float(pcts[2]), 4),
+            "p50": round(float(pcts[3]), 4),
+            "p75": round(float(pcts[4]), 4),
+            "p95": round(float(pcts[5]), 4),
+            "p99": round(float(pcts[6]), 4),
+            "zero_rate": round(float(1.0 - nonzero.size / finite.size), 4) if finite.size else None,
+            "missing_rate": round(float(1.0 - finite.size / col.size), 4),
+            "unique_count": int(np.unique(col[finite]).size) if finite.any() else 0,
+            "saturated_at_minus3": round(float((col[finite] <= -3.0).mean()), 4)
+            if finite.any()
+            else None,
+            "saturated_at_plus3": round(float((col[finite] >= 3.0).mean()), 4)
+            if finite.any()
+            else None,
+            "constant": bool(finite.any() and np.unique(col[finite]).size == 1),
+        }
+        # near-constant: 99% of values identical
+        if finite.any() and np.unique(col[finite]).size > 1:
+            vc = np.unique(col[finite], return_counts=True)
+            report[fname]["near_constant"] = bool((vc[1].max() / col[finite].size) >= 0.99)
+        else:
+            report[fname]["near_constant"] = False
+    report["_meta"] = {
+        "probe": "TASK-04 brief-8 liquidity distribution audit",
+        "vectors_total": int(all_v.shape[0]),
+        "feature_names": list(LIQUIDITY_FEATURE_NAMES),
+        "regimes": {k: len(v) for k, v in per_regime.items()},
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "note": "SYNTHETIC deterministic regimes (fixtures) — real-market audit "
+        "requires the 70D dataset (TASK-3). Distribution shape is "
+        "informative; absolute rates are fixture-dependent.",
+    }
+    return report
+
+
+if __name__ == "__main__":
+    rep = main()
+    out = "scratch/liq60d_distribution_audit.json"
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(rep, f, indent=2)
+    # human summary to stdout
+    print(f"{'feature':<28}{'min':>8}{'max':>8}{'mean':>8}{'zero%':>8}{'sat+3%':>8}{'uniq':>6}")
+    for name, d in rep.items():
+        if name.startswith("_"):
+            continue
+        print(
+            f"{name:<28}{d['min']:>8}{d['max']:>8}{d['mean']:>8}"
+            f"{d['zero_rate'] * 100:>7.1f}%{d['saturated_at_plus3'] * 100:>7.1f}%{d['unique_count']:>6}"
+        )
+    print(f"\nvectors: {rep['_meta']['vectors_total']} | regimes: {rep['_meta']['regimes']}")

--- a/tests/helpers/liq60d_redundancy_audit.py
+++ b/tests/helpers/liq60d_redundancy_audit.py
@@ -1,0 +1,178 @@
+"""TASK-04-70D-MODEL-VALIDATION — Liquidity-vs-Base feature redundancy audit (brief 9).
+
+Executable TODAY: compute the 50D base + 10D liquidity vectors on the same
+deterministic windows and report Pearson/Spearman between every liquidity
+feature and every base feature (max |corr|, near-duplicate detection).
+
+Purpose: does the Liquidity block add NEW information or merely re-encode
+the existing 50D structure? Flag |r| >= 0.85 as near-duplicate (redundant).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import numpy as np
+
+from nexus_scalp.domain.models import TickData
+from nexus_scalp.features.liquidity_engine import (
+    LIQUIDITY_FEATURE_NAMES,
+    compute_liquidity_features,
+)
+from nexus_scalp.features.scalp_features import (
+    FEATURE_NAMES,
+    ScalpFeatureEngine,
+)
+from tests.helpers.liquidity_fixtures import (
+    bar,
+    steady_bars,
+    swing_high_bars,
+    swing_low_bars,
+)
+
+
+def _pearson(a: np.ndarray, b: np.ndarray) -> float:
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = np.sqrt((a * a).sum() * (b * b).sum())
+    if denom == 0.0:
+        return 0.0
+    return float((a * b).sum() / denom)
+
+
+def _spearman(a: np.ndarray, b: np.ndarray) -> float:
+    ra = np.argsort(np.argsort(a)).astype(float)
+    rb = np.argsort(np.argsort(b)).astype(float)
+    return _pearson(ra, rb)
+
+
+def _sweep_bars() -> list:
+    rng = np.random.default_rng(42)
+    t0 = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    bars, price = [], 3300.0
+    for i in range(70):
+        drift = 0.08 if i < 45 else -0.12
+        o = price
+        c = o + drift + float(rng.normal(0, 0.02))
+        h = max(o, c) + 0.15
+        l = min(o, c) - 0.15
+        if i == 55:
+            h = max(h, 3350.0)
+            c = 3348.0
+        bars.append(bar(i, t0, o, h, l, c, vol=150 if i != 55 else 600))
+        price = c
+    return bars
+
+
+def _volatile_bars() -> list:
+    t0 = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    bars, base = [], 3300.0
+    for i in range(90):
+        o = base
+        up = i % 2 == 0
+        c = base + (0.4 if up else -0.4)
+        h = max(o, c) + 0.6
+        l = min(o, c) - 0.6
+        bars.append(bar(i, t0, o, h, l, c, vol=300))
+        base = c
+    return bars
+
+
+def _random_walk(seed: int = 1) -> list:
+    rng = np.random.default_rng(seed)
+    t0 = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    bars, price = [], 3300.0
+    for i in range(400):
+        o = price
+        c = o + float(rng.normal(0, 0.15))
+        h = max(o, c) + abs(float(rng.normal(0, 0.2)))
+        l = min(o, c) - abs(float(rng.normal(0, 0.2)))
+        bars.append(bar(i, t0, o, h, l, c, vol=int(rng.integers(80, 400))))
+        price = c
+    return bars
+
+
+def main() -> dict:
+    regimes = {
+        "TRENDING_UP": swing_high_bars(60, 3350.0, 3300.0),
+        "TRENDING_DOWN": swing_low_bars(60, 3250.0, 3300.0),
+        "RANGING": steady_bars(100),
+        "VOLATILE": _volatile_bars(),
+        "SWEEP": _sweep_bars(),
+        "RANDOM_WALK": _random_walk(),
+    }
+    base_rows: list[np.ndarray] = []
+    liq_rows: list[np.ndarray] = []
+    engine = ScalpFeatureEngine(symbol="XAUUSD")
+    for _name, bars in regimes.items():
+        for start in range(0, max(len(bars) - 55, 1), 5):
+            win = bars[start : start + 56]
+            if len(win) < 56:
+                continue
+            last = win[-1]
+            tick = TickData(
+                symbol="XAUUSD",
+                timestamp=last.timestamp,
+                bid=float(last.close),
+                ask=float(last.close) + 0.5,
+                volume=int(last.tick_volume or 0),
+            )
+            try:
+                fv = engine.compute_from_bars(win, tick)
+                x50 = np.asarray(fv.to_tensor_input(), dtype=float)
+                lf = compute_liquidity_features(
+                    win,
+                    decision_at=last.timestamp,
+                    mid_price=float(last.close),
+                    atr=fv.atr_m1,
+                )
+                xl = np.asarray(lf.as_vector(), dtype=float)
+                base_rows.append(x50)
+                liq_rows.append(xl)
+            except Exception:
+                continue
+    B = np.vstack(base_rows)
+    L = np.vstack(liq_rows)
+
+    report: dict = {}
+    flag_threshold = 0.85
+    for j, lname in enumerate(LIQUIDITY_FEATURE_NAMES):
+        pearson_max = 0.0
+        spearman_max = 0.0
+        for i, bname in enumerate(FEATURE_NAMES):
+            pc = _pearson(B[:, i], L[:, j])
+            sc = _spearman(B[:, i], L[:, j])
+            if abs(pc) > abs(pearson_max):
+                pearson_max, best_pearson = pc, bname
+            if abs(sc) > abs(spearman_max):
+                spearman_max, best_spearman = sc, bname
+        report[lname] = {
+            "best_pearson_with": best_pearson,
+            "pearson": round(pearson_max, 4),
+            "best_spearman_with": best_spearman,
+            "spearman": round(spearman_max, 4),
+            "near_duplicate": max(abs(pearson_max), abs(spearman_max)) >= flag_threshold,
+        }
+    report["_meta"] = {
+        "probe": "TASK-04 brief-9 liquidity-vs-base redundancy audit",
+        "vectors": int(B.shape[0]),
+        "flag_threshold_abs_corr": flag_threshold,
+        "note": "SYNTHETIC deterministic regimes — structure informative; real "
+        "market rates need the 70D dataset (TASK-3).",
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+    }
+    return report
+
+
+if __name__ == "__main__":
+    rep = main()
+    with open("scratch/liq60d_redundancy_audit.json", "w", encoding="utf-8") as f:
+        json.dump(rep, f, indent=2)
+    print(f"{'feature':<28}{'best-base':<28}{'pearson':>9}{'spearman':>9}  flag")
+    for name, d in rep.items():
+        if name.startswith("_"):
+            continue
+        flag = "NEAR-DUP" if d["near_duplicate"] else ""
+        print(f"{name:<28}{d['best_pearson_with']:<28}{d['pearson']:>9}{d['spearman']:>9}  {flag}")
+    print(f"\nvectors: {rep['_meta']['vectors']}")

--- a/tests/unit/test_70d_model_validation_task4.py
+++ b/tests/unit/test_70d_model_validation_task4.py
@@ -743,10 +743,10 @@ def test_70d_model_26_liquidity_distribution_audit_smoke() -> None:
     import importlib.machinery
     import importlib.util
 
-    # Audit module lives in scratch/archive/historic-20260823/ (commit
-    # d49e4cf6 quarantined 215 historic probes). No parent __init__.py;
-    # load by file location so the smoke still exercises the REAL module.
-    _leaf = REPO_ROOT / "scratch/archive/historic-20260823/liq60d_distribution_audit.py"
+    # Audit module lives in tests/helpers/ (restored after a77f8315 deleted
+    # scratch/, which orphaned this path-load and broke CI-only). Load by file
+    # location so the smoke still exercises the REAL module source.
+    _leaf = REPO_ROOT / "tests/helpers/liq60d_distribution_audit.py"
     _loader = importlib.machinery.SourceFileLoader("liq60d_distribution_audit", str(_leaf))
     _spec = importlib.util.spec_from_loader(_loader.name, _loader, origin=str(_leaf))
     dist_audit_mod = importlib.util.module_from_spec(_spec)
@@ -769,7 +769,7 @@ def test_70d_model_27_liquidity_redundancy_audit_smoke() -> None:
     import importlib.machinery
     import importlib.util
 
-    _leaf2 = REPO_ROOT / "scratch/archive/historic-20260823/liq60d_redundancy_audit.py"
+    _leaf2 = REPO_ROOT / "tests/helpers/liq60d_redundancy_audit.py"
     _loader2 = importlib.machinery.SourceFileLoader("liq60d_redundancy_audit", str(_leaf2))
     _spec2 = importlib.util.spec_from_loader(_loader2.name, _loader2, origin=str(_leaf2))
     red_audit_mod = importlib.util.module_from_spec(_spec2)

--- a/tests/unit/test_experience_intelligence.py
+++ b/tests/unit/test_experience_intelligence.py
@@ -1331,10 +1331,14 @@ def test_40_large_experience_set_is_handled(temp_audit_repo, components):
 
 
 def test_41_existing_signal_pipeline_unchanged():
-    """SignalPolicy defaults must be untouched by Phase 08."""
+    """SignalPolicy default confidence_threshold must stay the canonical
+    ModelConfig value (0.35 since d57d003d); SignalPolicy falls back to it
+    when no explicit threshold is passed (policy.py)."""
+    from nexus_scalp.configuration.config import ModelConfig
     from nexus_scalp.signals.policy import SignalPolicy
 
-    assert SignalPolicy().confidence_threshold == 0.20
+    assert ModelConfig().confidence_threshold == 0.35
+    assert SignalPolicy().confidence_threshold == 0.35
 
 
 def test_42_existing_risk_engine_unchanged():


### PR DESCRIPTION
# NSE-Swarm PR: restore liq60d audit helpers (TASK4-SCRATCH-PROBES) + test_41 stale pin

## Why
- a77f8315 deleted `scratch/` while `tests/unit/test_70d_model_validation_task4.py:749/772` still path-load `scratch/archive/historic-20260823/liq60d_{distribution,redundancy}_audit.py` → FileNotFoundError, CI-only (a local untracked scratch/ copy hides it). Confirmed live at HEAD d96760be: `git ls-tree HEAD scratch/` = empty; both modules exist at 7cbe6566 (ancestor) via `git cat-file -e`.
- `tests/unit/test_experience_intelligence.py:1337` pins `SignalPolicy().confidence_threshold == 0.20`; the canonical default is `ModelConfig.confidence_threshold = 0.35` (src/nexus_scalp/configuration/config.py:79), and SignalPolicy falls back to ModelConfig when no threshold is passed (src/nexus_scalp/signals/policy.py:85-89). Stale pin, red on every nightly/CI run of this file.

## What
- Restore both audit modules verbatim from 7cbe6566 into `tests/helpers/` (they already import `tests.helpers.liquidity_fixtures`, so the helpers tree is their native home).
- Repoint the two test path-loads (line 749/772) to `tests/helpers/`.
- Re-pin test_41 to the canonical 0.35 with the policy-fallback contract asserted explicitly (ModelConfig().confidence_threshold == 0.35 and SignalPolicy().confidence_threshold == 0.35).

## Verification (slim venv, worktree /tmp/nexus-task4fix at fda4a27e)
- RED before (local repro at d96760be): test_41 FAILED (0.35 != 0.20); both liq smokes FAILED FileNotFoundError.
- GREEN after: `pytest tests/unit/test_70d_model_validation_task4.py tests/unit/test_experience_intelligence.py` → 72 passed, 16 skipped (skips = 50D/70D artifact-gated, environment-only).
- `ruff check` + `ruff format --check` on all 4 touched files: clean. `mypy src/`: Success, no issues in 580 source files.
- No .github/workflows/*, no src/ product code touched (test-only + test helpers).

## Note
- test_41's docstring previously asserted "defaults untouched by Phase 08" against 0.20; the canonical value changed in d57d003d (0.20→0.35) and this test was missed. The new pin asserts the SSOT contract (ModelConfig is the ONE canonical default).
