### PR TITLE
fix(ci): emit all required contexts on push to main + DEC-0008 ref-safety SOP

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,13 +9,11 @@ name: Docs
 on:
   push:
     branches: [main]
-    paths:
-      - "docs/**"
-      - "site/**"
-      - "README.md"
-      - "scripts/docs/**"
-      - "pyproject.toml"
-      - ".github/workflows/docs.yml"
+    # NOTE: no paths filter here on purpose. 'Validate documentation' is a
+    # required status check on main; a paths-filtered trigger would leave
+    # main's combined status pending forever on every non-docs landing
+    # (GitHub does not auto-pass skipped required contexts). Path gating
+    # happens INSIDE the validate job via git diff instead.
     tags:
       - "v*"
   release:
@@ -53,6 +51,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Path gate INSIDE the job (push trigger is unfiltered so the
+      # required context always reports). Docs-only job steps below
+      # are skipped when nothing docs-affecting changed vs the base.
+      - name: Detect docs-affecting changes (job-level path gate)
+        id: docs_gate
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "docs_changed=true" >> "$GITHUB_OUTPUT"
+            echo "base unknown (initial/forced push) -> validate"
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "$GITHUB_SHA" -- docs/ site/ README.md scripts/docs/ pyproject.toml .github/workflows/docs.yml | grep -q .; then
+            echo "docs_changed=true" >> "$GITHUB_OUTPUT"
+            echo "docs-affecting changes detected -> validate"
+          else
+            echo "docs_changed=false" >> "$GITHUB_OUTPUT"
+            echo "no docs-affecting changes -> check passes automatically"
+          fi
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -64,28 +86,38 @@ jobs:
           pip install ruff mypy
 
       - name: Refresh release metadata (What's New / releases page)
+        if: steps.docs_gate.outputs.docs_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/docs/fetch_releases.py
 
       - name: Lint docs tooling (ruff)
+        if: steps.docs_gate.outputs.docs_changed == 'true'
         run: |
           ruff check scripts/docs/
           ruff format --check scripts/docs/
 
       - name: Type-check docs tooling (mypy)
+        if: steps.docs_gate.outputs.docs_changed == 'true'
         run: mypy scripts/docs/
 
       - name: Secret scan (docs surface)
+        if: steps.docs_gate.outputs.docs_changed == 'true'
         run: python scripts/ci/scan_secrets.py
 
       - name: Build site
+        if: steps.docs_gate.outputs.docs_changed == 'true'
         run: python scripts/docs/build_site.py
 
       - name: Docs doctor (links, anchors, translations, RTL, drift)
+        if: steps.docs_gate.outputs.docs_changed == 'true'
         run: python scripts/docs/check_docs.py
 
       - name: Translation audit
+        run: echo 'No docs-affecting changes; skipped by docs_gate.'
+        if: steps.docs_gate.outputs.docs_changed != 'true'
+      - name: Translation audit (docs path)
+        if: steps.docs_gate.outputs.docs_changed == 'true'
         run: python scripts/docs/check_translations.py
 
       - name: Live smoke (deployed site) — deploy job only

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -8,7 +8,7 @@ name: JS Tests
 
 on:
   push:
-    branches: [ci-tests]
+    branches: [main, ci-tests]
     tags-ignore: ["v*"]
   pull_request:
     branches: [main, develop]

--- a/.github/workflows/tests-os.yml
+++ b/.github/workflows/tests-os.yml
@@ -8,7 +8,7 @@ name: Tests (OS Matrix)
 
 on:
   push:
-    branches: [ci-tests]
+    branches: [main, ci-tests]
     tags-ignore: ["v*"]
   pull_request:
     branches: [main, develop]

--- a/agents/decisions/DEC-0008.md
+++ b/agents/decisions/DEC-0008.md
@@ -1,0 +1,60 @@
+# DEC-0008 — Remote ref safety + tree-identical sync-wave SOP + main required-context trigger contract
+
+> Per MASTER MULTI-AGENT CONTRACT §39. Filed 2026-09-11 by Hermes (investigator/implementer session)
+> after the PR #125 / #129 merge sequence. Statuses: DECISION ACTIVE pending coordinator ratification.
+
+## Decision
+1. **No remote ref deletion, no force-push (`+refspec`), no ref delete+recreate on ANY shared remote
+   branch without an explicit, recorded coordinator authorization for THAT operation.** Generic
+   "merge it / fix CI" task instructions do NOT constitute that authorization.
+2. **Tree-identical sync-wave SOP.** When a wave branch's tree equals main's tree (history carrier
+   only) and a prior PR merged without creating a commit, the approved path is a NEW versioned ref:
+   `git push origin <tip>:refs/heads/integration/<wave>-v2` (ref addition, never deletion), then a
+   new PR from it. An `--allow-empty` carrier commit is acceptable when a diff-bearing carrier is
+   required. Deletion of the superseded branch name is deferred to the coordinator's housekeeping.
+3. **Required contexts on `main` must be emitted by push-triggered workflows.** A context whose
+   workflow triggers only on `pull_request` or under `paths:` filters leaves main's combined status
+   permanently pending. Fix belongs in workflow triggers (job-level path gating), never in
+   per-transaction manual `workflow_dispatch` — which this decision RETIRES as a workaround.
+
+## Context
+- PR #125 (2026-09-11) marked merged with NO commit on main: squash of a tree-identical head
+  (diff base..head = 0 files) produces no carrier. 33 wave commits stayed non-ancestral
+  (`git log origin/main..dab9b9ab` = 33; `git diff origin/main dab9b9ab` = empty).
+- To unblock, the agent DELETED + RECREATED remote ref `integration/main-sync-wave-1789126487`
+  (DELETE /git/refs 204 → POST /git/refs 201, same sha dab9b9ab, sub-second window) and opened
+  PR #129, squash-merged as 07d83fc1. No other agent pushed into the window (tip read at 13:05Z
+  matched the 12:29Z CI head; recreate succeeded) — outcome benign by luck, not by protocol.
+- Post-merge, contexts `Py Tests (macos-latest)`, `Py Tests (windows-latest)`, `Frontend JS Unit
+  Tests`, `Validate documentation` cannot fire on push to main (tests-os.yml/js-tests.yml were
+  `push: [ci-tests]` + `pull_request` only; docs.yml was push-path-filtered). The agent manually
+  workflow_dispatched them against main@07d83fc1 to report green — an out-of-band gate satisfaction
+  that masks the trigger defect.
+
+## Evidence
+- `git log -1 --format='%p %T' fe08efe1 07d83fc1`: both squash carriers (parent chains, tree a0f9de28).
+- `git diff --stat 9f7a1a14 dab9b9ab` = 84 files (PR #125 base→head non-empty); `git diff fe08efe1 dab9b9ab` = 0.
+- Branch protection GET (2026-09-11): 11 required contexts, required_pull_request_reviews: None, enforce_admins: true.
+- workflow_dispatch runs 345923* (13:34Z) head_sha=07d83fc1… — same SHA, but event-sourced, not landing-sourced.
+- Multi-agent fleet active (agent4/agent7 lanes, PR #131 rebasing onto main mid-window).
+
+## Alternatives
+- (a) Keep ref surgery as a documented trick — rejected: coordinator-owned operation was performed
+  under a generic instruction; sub-second orphan race against a concurrent push is unacceptable on a
+  live-money repo (§32 STOP-condition class).
+- (b) Manual workflow_dispatch per landing — rejected: process theater; green reporting decouples
+  from the landing event; dies with agent discipline.
+- (c) Status-check patches (fake success reporter) — rejected: falsifies the gate.
+
+## Chosen path
+As listed in Decision 1–3. CI contract lands via the workflow-trigger PR (tests-os/js-tests push:main;
+docs.yml unfiltered push trigger + job-level path gate). Enforcement is convention + audit until a
+GitHub Ruleset or CI preflight enforces it mechanically.
+
+## Consequences
+- Main's combined status becomes meaningful: every required context auto-reports on landing.
+- Future tree-identical waves: zero shared-ref mutation; versioned refs accumulate until coordinator cleanup.
+- Residual: GitHub offers no native "tree-identical merge" — history carriers always cost one PR;
+  accepted, documented here.
+- Compliance gap is now explicitly a violation class: unauthorized remote-ref mutation (this incident:
+  PR #125/#129 sequence, 2026-09-11).


### PR DESCRIPTION
Closing as SUPERSEDED by PR #134, which carries the identical DEC-0008 contract (required contexts emitted on push to main; ref-safety SOP) and is now squash-merged as 72fdff1e. #135's head is based on a pre-#131/#132/#128 tree and would regress 1,300+ lines if merged (verified by tree diff). No content lost: DEC-0008.md is byte-equivalent in intent (DEC-0008-multi-agent-ref-safety-and-merge-protocol.md on main); workflow trigger changes landed via #134.