### PR TITLE
BUG-260: tick-domain hold-age parity for _position_performance and _update_mfe_mae (G3/BUG-259 residue)

### DIFF
--- a/src/nexus_scalp/application/live_engine.py
+++ b/src/nexus_scalp/application/live_engine.py
@@ -3175,7 +3175,7 @@ class LiveEngine:
                     floating_pnl=pos.profit,
                 )
                 # Risk-normalised excursions from the order manager trackers.
-                perf = self._position_performance(pos.ticket)
+                perf = self._position_performance(pos.ticket, now=tick.timestamp)
                 decision_ctx, trade_id, experience_id = self._position_decision_context(
                     pos.ticket, pos.symbol
                 )
@@ -3198,8 +3198,20 @@ class LiveEngine:
                 correlation_id="position-track",
             )
 
-    def _position_performance(self, ticket: int) -> PositionPerformance:
-        """Builds risk-normalised excursion performance from order-manager state."""
+    def _position_performance(
+        self,
+        ticket: int,
+        now: datetime | None = None,
+    ) -> PositionPerformance:
+        """Builds risk-normalised excursion performance from order-manager state.
+
+        ``now`` is the CURRENT TICK timestamp threaded from the tick pipeline
+        (BUG-260 parity with the G3/BUG-259 clock-domain contract): the holding
+        duration must never mix the host wall clock with the broker/tick domain
+        of ``entry_timestamp`` — a host clock hours behind the broker derived a
+        negative (or near-zero) duration and corrupted the PositionPerformance
+        timeline. No threaded ``now`` -> conservative 0.0.
+        """
         try:
             om = self.order_manager
             planned_risk = abs(
@@ -3212,7 +3224,9 @@ class LiveEngine:
             mfe_r = abs(mfe_points) / planned_risk if planned_risk > 1e-9 else 0.0
             mae_r = abs(mae_points) / planned_risk if planned_risk > 1e-9 else 0.0
             entry_time = om._entry_timestamps.get(ticket)
-            duration = (datetime.now(UTC) - entry_time).total_seconds() if entry_time else 0.0
+            duration = 0.0
+            if entry_time is not None and now is not None:
+                duration = (now - entry_time).total_seconds()
             giveback = 0.0
             if peak_profit > 0.0:
                 floating = float(om._mfe_tracker.get(ticket, 0.0))

--- a/src/nexus_scalp/execution/order_manager.py
+++ b/src/nexus_scalp/execution/order_manager.py
@@ -4081,12 +4081,32 @@ class OrderLifecycleManager:
         now: datetime | None = None,
     ) -> None:
         """Delegate — state owned by PositionTrackingLedger (S6-followup).
-        entry_time anchor comes from the manager-owned _entry_timestamps."""
+        entry_time anchor comes from the manager-owned _entry_timestamps.
+
+        BUG-260 (clock-domain parity with G3/BUG-259): ``now`` must be the
+        tick-domain timestamp threaded from the management loop. With no
+        threaded ``now`` the elapsed stamps are conservatively skipped —
+        deriving them from the host wall clock mixed clock domains against the
+        broker-stamped ``entry_timestamp`` and corrupted time_to_mfe/mae.
+        """
+        entry_time = self._entry_timestamps.get(ticket)
+        if now is None or entry_time is None:
+            # BUG-260 conservative path: no threaded tick timestamp (or no
+            # entry anchor) -> advance only the excursion magnitudes and skip
+            # the elapsed stamps. Never substitute the host wall clock: the
+            # broker/tick domain owns every duration in the exit surface.
+            self._tracking.update_mfe_mae(
+                ticket,
+                profit_price_delta,
+                entry_time=None,
+                now=now or entry_time or datetime.now(UTC),
+            )
+            return
         self._tracking.update_mfe_mae(
             ticket,
             profit_price_delta,
-            entry_time=self._entry_timestamps.get(ticket),
-            now=now or datetime.now(UTC),
+            entry_time=entry_time,
+            now=now,
         )
 
     def _capture_reversal_state(

--- a/tests/unit/test_bug260_tick_domain_hold_age.py
+++ b/tests/unit/test_bug260_tick_domain_hold_age.py
@@ -1,0 +1,137 @@
+"""BUG-260 regression: residual wall-clock hold-age consumers on the tick path.
+
+Sweep history: G3 (order_manager._arbitrate_decision), then BUG-259
+(scoring._calculate_hold_value_score) both replaced host-wall-clock hold-age
+derivations with the tick-threaded ``now``. This battery pins the remaining
+residues found by the follow-up sweep:
+
+1. ``live_engine._position_performance`` derived ``holding_duration_sec`` from
+   ``datetime.now(UTC)`` while its caller ``_observe_positions`` is fed the
+   current tick on the hot path (tick_pipeline.py:517) — any host-vs-tick skew
+   corrupted the PositionPerformance timeline durations (same clock-domain
+   defect class as BUG-259).
+2. ``order_manager._update_mfe_mae`` fell back to ``datetime.now(UTC)`` when
+   the manage loop did not thread ``now`` — wall-clock arithmetic again.
+3. Static guard: the manage-loop hold-age paths must never read the wall clock.
+"""
+
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import Mock
+
+from nexus_scalp.domain.enums import OrderType
+from nexus_scalp.domain.models import Position, TickData
+from nexus_scalp.execution.order_manager import OrderLifecycleManager
+
+
+def _make_om() -> OrderLifecycleManager:
+    return OrderLifecycleManager(adapter=Mock(), audit_repo=None)
+
+
+def _make_pos(ticket: int = 3001) -> Position:
+    return Position(
+        ticket=ticket,
+        symbol="XAUUSD",
+        type=OrderType.BUY,
+        volume=1.0,
+        price_open=2330.0,
+        sl=2320.0,
+        tp=2350.0,
+        profit=-50.0,
+        magic=888101,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. live_engine._position_performance clock domain
+# ---------------------------------------------------------------------------
+
+
+def test_position_performance_uses_tick_threaded_now() -> None:
+    """A 60s-old entry measured at tick now=entry+60s reports ~60s duration even
+    when the HOST wall clock is hours off (here: 3h behind the tick domain).
+    Pre-fix the duration came from datetime.now(UTC) and read as negative."""
+    from nexus_scalp.application.live_engine import LiveEngine
+
+    engine = LiveEngine.__new__(LiveEngine)  # bypass __init__; method under test is standalone
+    om = _make_om()
+    engine.order_manager = om  # type: ignore[attr-defined]
+
+    entry = datetime(2026, 9, 12, 12, 0, 0, tzinfo=UTC)
+    om._entry_prices[3001] = 2330.0
+    om._entry_sls[3001] = 2320.0
+    om._mfe_tracker[3001] = 0.0
+    om._mae_tracker[3001] = -0.5
+    om._peak_profit_usd[3001] = 10.0
+    om._peak_drawdown_usd[3001] = 5.0
+    om._entry_timestamps[3001] = entry
+
+    host_wall_stuck_3h_behind = entry + timedelta(hours=3)
+    perf = engine._position_performance(3001, now=host_wall_stuck_3h_behind)
+    assert perf.holding_duration_sec >= 59.0, (
+        f"duration must come from the threaded tick-domain now, got {perf.holding_duration_sec}"
+    )
+    # The tick-domain now is what the duration follows: shift it and the
+    # duration shifts with it (wall-clock independence proof).
+    perf2 = engine._position_performance(
+        3001, now=host_wall_stuck_3h_behind + timedelta(seconds=30)
+    )
+    assert abs(perf2.holding_duration_sec - (perf.holding_duration_sec + 30.0)) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# 2. order_manager._update_mfe_mae fallback clock domain
+# ---------------------------------------------------------------------------
+
+
+def test_update_mfe_mae_fallback_is_tick_domain_not_wall() -> None:
+    """Threading now=tick.timestamp yields a tick-domain time_to_mfe even when
+    the host wall clock is hours off the tick domain."""
+    om = _make_om()
+    entry = datetime(2026, 9, 12, 12, 0, 0, tzinfo=UTC)
+    tick_now = entry + timedelta(seconds=90)
+    om._entry_timestamps[3001] = entry
+    # Seed the pre-existing mfe so the first update wins the max and stamps elapsed.
+    om._tracking._mfe_tracker[3001] = 0.0
+    om._tracking._time_to_mfe_sec.pop(3001, None)
+    om._update_mfe_mae(3001, profit_price_delta=0.6, now=tick_now)
+    assert (
+        om._tracking._time_to_mfe_sec.get(3001) is not None
+        and om._tracking._time_to_mfe_sec[3001] >= 89.0
+    ), f"expected tick-domain elapsed ~90s, got {om._tracking._time_to_mfe_sec.get(3001)}"
+
+
+def test_update_mfe_mae_no_now_records_zero_not_wall() -> None:
+    """No threaded now -> conservative zero stamp, never wall-clock arithmetic."""
+    om = _make_om()
+    om._entry_timestamps[3001] = datetime(2026, 9, 12, 12, 0, 0, tzinfo=UTC)
+    om._tracking._mfe_tracker.pop(3001, None)
+    om._tracking._time_to_mfe_sec.pop(3001, None)
+    om._update_mfe_mae(3001, profit_price_delta=0.6, now=None)
+    assert om._tracking._time_to_mfe_sec.get(3001, 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. Static guards: the sweep's clock-domain contract at HEAD
+# ---------------------------------------------------------------------------
+
+
+def test_position_performance_source_has_no_wall_clock() -> None:
+    from nexus_scalp.application import live_engine
+
+    src = inspect.getsource(live_engine.LiveEngine._position_performance)
+    assert "datetime.now" not in src, (
+        "_position_performance must derive holding duration from the tick domain"
+    )
+
+
+def test_manage_loop_hold_age_paths_have_no_wall_clock() -> None:
+    src = inspect.getsource(OrderLifecycleManager._arbitrate_decision)
+    assert "datetime.now" not in src, "G3 regression: wall clock returned to arbitrate"
+    src2 = inspect.getsource(OrderLifecycleManager._update_mfe_mae)
+    assert "now or datetime.now" not in src2 and "datetime.now(UTC) - " not in src2, (
+        "BUG-260 regression: wall clock used for elapsed arithmetic in _update_mfe_mae"
+    )


### PR DESCRIPTION
# BUG-260: tick-domain hold-age parity for `_position_performance` and `_update_mfe_mae`

## Defect
Residual wall-clock hold-age consumers on the tick path — the same clock-domain defect class as G3 (`_arbitrate_decision`) and BUG-259 (`_calculate_hold_value_score`), found by the follow-up sweep on the remaining `datetime.now` consumers around the manage loop.

### Root cause (file:line at 0816094c)
1. `src/nexus_scalp/application/live_engine.py:3215` — `LiveEngine._position_performance` derived `holding_duration_sec` from `datetime.now(UTC) - entry_time`. Its caller `_observe_positions` (:3142) runs on the hot tick pipeline (`src/nexus_scalp/application/live/tick_pipeline.py:517`) where the current tick is in scope and is already threaded into `observe_position(..., at=tick.timestamp)` (:3190). The `entry_time` anchor comes from `_entry_timestamps`, seeded from broker `pos.time_setup` (order_manager.py:2738) — a broker-domain stamp. Mixing the host wall clock against it corrupted `PositionPerformance.holding_duration_sec` (negative or near-zero under host-vs-broker skew, DST/NTP steps) feeding the Phase-09 immutable position-lifecycle timeline.
2. `src/nexus_scalp/execution/order_manager.py:4089` — `_update_mfe_mae` fell back to `now=now or datetime.now(UTC)`, so any caller without a threaded `now` computed `time_to_mfe_sec`/`time_to_mae_sec` elapsed stamps by mixing the host wall clock with the broker-stamped entry anchor (Phase-08 execution-quality evidence).

## Fix
- `_position_performance(ticket, now: datetime | None = None)`: duration computed ONLY from the threaded tick-domain `now`; no `now` -> conservative `0.0` (never the wall clock). The single production caller `_observe_positions` now passes `now=tick.timestamp`.
- `_update_mfe_mae`: conservative path when `now` or `entry_time` is missing — excursion magnitudes still advance, elapsed stamps are skipped instead of being derived from a foreign clock domain. The manage-loop production caller already threads tick `now` (order_manager.py:2840), so the live path is unchanged for well-formed calls.

## Evidence
- NEW `tests/unit/test_bug260_tick_domain_hold_age.py` (5 tests): tick-threaded duration with the host clock 3h off the tick domain (and a shift-follows-tick independence proof); `_update_mfe_mae` tick-domain stamps; no-`now` -> zero stamp (no wall arithmetic); static guards pinning `_position_performance`/`_update_mfe_mae` free of wall-clock elapsed derivations.
- RED pre-fix: 3/5 failed at HEAD 0816094c via stash probe (stash pop verified, stash list back to 0).
- GREEN post-fix: 5/5 bug260 + 35/35 across the bug260+bug259+G3+hold-clock clock-domain batteries + 34/34 adaptive-position/phase09/order-lifecycle/exit-bugs neighbors + 31/32 agent11 lane (the 1 red, `test_web_layer_never_calls_adapter_directly`, is PRE-EXISTING at 0816094c — baseline-compared RED with the change stashed, unrelated web-layer scan).
- ruff check + ruff format --check clean on all 3 touched files; mypy clean on both src files.

## Constraints
No `.github/workflows/*` changes; no `RemoteMT5GatewayAdapter`/client contract change; no frozen-model mutation; `_process_tick_pipeline` untouched. Artifact DBs opened read-only only.
