### PR TITLE
NSE-Swarm deplock: regen lock (pyinstaller 6.22.3) - clears dependency-drift red at 60b785d3

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -1344,19 +1344,19 @@ pygments==2.21.0 \
     #   nexus-scalp-engine (pyproject.toml)
     #   pytest
     #   rich
-pyinstaller==6.22.2 \
-    --hash=sha256:0260eaad6be3f6fbc1affffe6dc7b8e5b636dbca51b463224daba971610b6fc1 \
-    --hash=sha256:06d7b3827a8049db4a2d47e3ec4ae2f69a1041577d8833b8f169745cde573ab4 \
-    --hash=sha256:7bee432404eca5dc3ef37c36811c266561b03988f6d3e70ab0fa5352dd5de9e4 \
-    --hash=sha256:89b65a3ad07d9dd5832253e37bc45f31872d10d7f9d5c9fd0fdd6088a83829dd \
-    --hash=sha256:8c2c4b14caad38c1f3df8e9bf5276fc265e27fe8b4180cab4a37864288427bc0 \
-    --hash=sha256:9622686ecc5d5fa492fe6cde29d47df9dd41138cff8177be9f901ca3260f2096 \
-    --hash=sha256:9a078877caa3920558a3242d0a7019fe5b825cff4b65ed380c7d1e1bd200ddd9 \
-    --hash=sha256:9b990fa6bbe143572f06644a984ad0d7aa2e2ccc6929d4916031343a5888e9a7 \
-    --hash=sha256:afb6f9a95d19b6dcd3a7decc40d9adb6ba9c4f8802ddd6c972dfb552953f384e \
-    --hash=sha256:becb47ad78272bede87acf2ed830d7545a8f65ab11d06a68fe2b99ba1afaac6d \
-    --hash=sha256:ebd1b1ca932d7cf25d7366ce691aaf79a5ff9425811ed7328b5116e4471b6d6d \
-    --hash=sha256:f5ccb847451df4207bce18bf53a57b124c9bb4e7e4bad08c5ecc627bcf00b28c
+pyinstaller==6.22.3 \
+    --hash=sha256:020d4fe0627f5c73dfbcfad1a6578ef354d5fe4bdccd9d8e5a615528f5a45d2b \
+    --hash=sha256:052f4a1cd4f81092ccb7a18fe8ebc9ecf832a5917317e39fb3775af4e959b253 \
+    --hash=sha256:05eb2f5615503e72939a7224d68b4aff572c6b0438ee4a17d0a4b481f399362d \
+    --hash=sha256:312da84b4b31ab9750066a823734c11b7c68757fdd67c9f038bf19c330a954e4 \
+    --hash=sha256:31df3cc4261e804a53d358b7897c293ec8b88b167a7cca06c78018085c855f97 \
+    --hash=sha256:451a4ae14b719365bf1a2f0a99dae7b3463060061c3a394c70d5264cfb439528 \
+    --hash=sha256:46a3e30a118341a1ec20667a5a95aa7e0aa8c4fa129893c0151b3eb3f801a722 \
+    --hash=sha256:500bd58c7bf7e584a8435adccbd763a0b918d5c12b08d74ff50fd79b2915458b \
+    --hash=sha256:9e4f7bd64b2103f14b4a6240fb9155e9fe7bc61391b4043bbddb7d3ebc8ab0fa \
+    --hash=sha256:a2b6fc26601e8c2596c3d54981566934a3382e85d05d0fe91b55b6a8dcc6b282 \
+    --hash=sha256:ea240b5dfa831ff673c97505eee0ec24670bccf71396c83109440348944c83d0 \
+    --hash=sha256:f82d0fb89f21c3ed6f482ee16f341bc59e8a31dbabb9bae9ef04e53ade4dc0d9
     # via nexus-scalp-engine (pyproject.toml)
 pyinstaller-hooks-contrib==2026.7 \
     --hash=sha256:24257a04c7a5a7a034cf28e39dcee20fbeeb9f043076729480f2e1b69904408a \

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pyarrow==25.0.1
 pydantic-settings==2.15.0
 pydantic==2.13.5
 pygments==2.21.0
-pyinstaller==6.22.2
+pyinstaller==6.22.3
 pynacl==1.6.2
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0


### PR DESCRIPTION
## What
Regenerate the two generated lock artifacts from pyproject.toml: pyinstaller 6.22.2 -> 6.22.3 (new upstream release; pyproject range is >=6.0.0 so resolution moved).

## Why
Dependency drift gate (required check) is RED on main at 60b785d3: 'requirements.lock is STALE vs pyproject.toml' + 'requirements.txt pin pyinstaller==6.22.2 != lock arms [6.22.3]' (run 34721436069, job 103627945359, CI 21:58Z). True positive, not the 3.12-host false-positive shape: CI resolver sees the pinned 3.11 + uv 0.12.10; local regen with the same uv produces the identical single-package diff.

## Verification
- python3 scripts/ci/check_dependency_drift.py --regen then plain check: OK (98 pins), RC=0
- git diff: only pyinstaller version+hash lines changed in the lock; only the pyinstaller pin in requirements.txt
- tests/unit/test_dependency_drift_resolver.py green on slim venv (3 passed)
- No .github/workflows, no code changes.
