### PR TITLE
feat(web): standalone alt-console host scripts/serve_alt_ui.py (BACKEND-1 lane)

### DIFF
--- a/scripts/README-alt-ui.md
+++ b/scripts/README-alt-ui.md
@@ -1,0 +1,89 @@
+# Standalone Alt-Console Host — `scripts/serve_alt_ui.py`
+
+**Lane:** standalone-server (BACKEND-1/5). A dependency-free host that runs
+the alternative React console (`frontend/`) on its own port, decoupled from
+the engine's FastAPI process, while the **engine backend stays the single
+source of truth**.
+
+Stdlib only (`http.server` + `threading` + `http.client`) — no Node runtime
+in production (DEC-0002), no new Python dependencies. Runs with the repo
+venv python.
+
+## What it does
+
+| Concern | Behavior |
+|---|---|
+| Port / bind | `--port` (default **8088**), binds **127.0.0.1** unless `--host`/`--allow-remote` |
+| Static | serves `--dist` (default `<repo>/frontend/dist`, `NEXUS_ALT_UI_DIR` fallback); the vite `base:"/alt/"` prefix is accepted and transparently stripped (`/alt/assets/x.js` → `dist/assets/x.js`) |
+| SPA fallback | unknown non-API path + `Accept: text/html` → `index.html` (deep links like `/positions` work); otherwise 404 JSON envelope |
+| Proxy | `/api`, `/health`, `/healthz` (+ subpaths) → `--backend` (default `http://127.0.0.1:8080`, `NSE_API_ORIGIN` fallback). Methods GET/HEAD/POST/PUT/PATCH/DELETE/OPTIONS, body (1 MiB `Content-Length` guard), query string |
+| Header passthrough | **only** `content-type`, `accept`, `x-nse-token`, `cookie`, `authorization` + `X-Request-ID` + a corrected `Host`. Everything else is dropped |
+| Response relay | upstream status/headers/body; hop-by-hop headers stripped (`connection`, `keep-alive`, `transfer-encoding`, …); `Content-Length` corrected to the relayed body |
+| SSE | any upstream `text/event-stream` (primary route `/api/ticks/stream`) is relayed **unbuffered**: `read1(≤64 KiB)` → write → `flush`, per chunk; `X-Accel-Buffering: no` + `Connection: close`; client disconnect tears the upstream down immediately |
+| Correlation | incoming `X-Request-ID` honored (else `req_<10 hex>` minted), forwarded upstream, echoed on every response, present in every log line and error envelope |
+| Fail-closed | backend unreachable → **502** `{"ok":false,"available":false,"success":false,"error":{"code":"BACKEND_UNREACHABLE","message":…,"request_id":…}}` (v1 envelope style, `web/errors.safe_error_payload` shape). API answers **never** come from disk/cache — even when `dist/api/...` files exist and even for `Accept: text/html` |
+| Traversal | `..` (literal, `%2e`, double-encoded `%252e`), backslashes, NUL → 404 envelope for **all** routes (proxy included); `realpath` + `commonpath` containment re-checked at resolution; symlink escapes refused; no directory listing ever |
+| Caching | `index.html`: `no-store`; hashed `assets/*-<hash>.<ext>`: `max-age=31536000, immutable`; everything else `no-store`; `X-Content-Type-Options: nosniff` |
+| Logging | one access line per request, `?token=` redacted; Authorization / Cookie / X-NSE-Token **values are never logged** |
+
+## Run
+
+```bash
+# repo root, with the engine backend on its default port:
+./.venv/Scripts/python.exe scripts/serve_alt_ui.py
+
+# explicit:
+./.venv/Scripts/python.exe scripts/serve_alt_ui.py \
+    --port 8088 --backend http://127.0.0.1:8080 --dist frontend/dist
+
+# this dev box note: NVIDIA Broadcast occupies 127.0.0.1:8080 — point at
+# wherever the test engine runs (same knob vite dev uses):
+NSE_API_ORIGIN=http://127.0.0.1:8099 ./.venv/Scripts/python.exe scripts/serve_alt_ui.py
+```
+
+Then open `http://127.0.0.1:8088/alt` (or `/`). Authenticate exactly as the
+console does against the engine: the login/token the backend issues (Bearer /
+`X-NSE-Token` / the HttpOnly `nse_web_auth` cookie) passes through untouched.
+
+## Test
+
+```bash
+./.venv/Scripts/python.exe -m pytest -p no:cacheprovider \
+    tests/unit/test_alt_ui_standalone_server.py
+```
+
+Fully offline: an in-test stub upstream (SSE frames with timed gaps, JSON
+echo, 401 route, chunked route) + a temp dist dir. Covers routing, MIME +
+cache policy, SPA fallback, 9 traversal vectors, header allowlist +
+credential passthrough, query forwarding, request-id echo, POST body guard
+(413 without consuming the upload), chunked re-framing, SSE per-chunk
+arrival timing + upstream teardown on client hangup, the 502 fail-closed
+envelope with a dead backend, and log redaction (via `caplog`).
+
+## Auth model — read before `--allow-remote`
+
+This host enforces **nothing**. WEB-AUTH-P0 (`src/nexus_scalp/web/auth.py`)
+lives in the backend; the proxy simply carries the caller's credentials to
+it. The static SPA bundle is public by design (the backend allowlists
+`/assets/` identically). Loopback binding keeps the trust boundary identical
+to the engine's own. `--allow-remote` (bind `0.0.0.0`) prints a loud warning
+and should be treated as: *exposing an unauthenticated, cleartext port to
+the control plane* — trusted LAN only, never with the engine in LIVE mode.
+
+## Limitations
+
+- **No TLS** (neither direction) — keep it localhost-only. `https://`
+  backends are refused at startup on purpose.
+- Thread-per-connection (`ThreadingHTTPServer`): fine for a console; under
+  many simultaneous SSE streams + large static downloads it is a bottleneck
+  compared to uvicorn. Long upstream keeps (many hours) pin one thread each.
+- Non-SSE proxy responses are buffered in memory (bounded by backend
+  behavior, not by this host) so `Content-Length` can be corrected; huge
+  streaming downloads with a content-type other than `text/event-stream`
+  are not relayed incrementally.
+- Chunked request uploads are refused (400); the 1 MiB body guard rejects
+  oversized uploads with 413 without reading them.
+- HTTP/1.1 only; no HTTP/2, no compression applied by this host (upstream
+  `content-encoding` passes through untouched).
+- `/ws` and `/web` are NOT proxied: production uvicorn boots with `ws="none"`
+  and the realtime transport is SSE (`/api/ticks/stream`).

--- a/scripts/serve_alt_ui.py
+++ b/scripts/serve_alt_ui.py
@@ -1,0 +1,839 @@
+#!/usr/bin/env python3
+"""STANDALONE-ALT-UI (lane BACKEND-1): a dependency-free alt-console host.
+
+Why this exists
+---------------
+The alternative React console (``frontend/``) is normally mounted by the
+FastAPI engine process at ``/alt`` (see ``src/nexus_scalp/web/server.py``,
+ALT-UI mount) and proxied in development by Vite (``frontend/vite.config.ts``).
+Both couple the console to the engine process/port. This script decouples
+them: it runs on its OWN port (default 8088), serves the built
+``frontend/dist`` as a pure static SPA, and reverse-proxies every API route
+(``/api`` ``/health`` ``/healthz``) to the authoritative engine backend
+(default ``http://127.0.0.1:8080``). The backend stays the single source of
+truth — this host NEVER answers an API request from cache or disk (fail-closed:
+if the backend is down the caller gets a 502 envelope, never stale HTML).
+
+Stdlib only (``http.server`` + ``threading`` + ``http.client``): no Node
+runtime in production (DEC-0002) and no new Python dependencies — it runs with
+the repo venv python as-is.
+
+Auth model (READ BEFORE USING ``--allow-remote``)
+-------------------------------------------------
+This host enforces NOTHING: WEB-AUTH-P0 lives in the backend. The proxy
+forwards ONLY an allowlisted header set — ``content-type``, ``accept``,
+``x-nse-token``, ``cookie``, ``authorization`` — plus ``X-Request-ID``
+correlation and a corrected ``Host``. So the caller's Bearer token /
+``X-NSE-Token`` header / HttpOnly ``nse_web_auth`` cookie ride through
+untouched and the backend's 401/200 decisions are relayed verbatim. The
+static SPA bundle itself is public by design (the backend allowlists
+``/assets/`` the same way — ``src/nexus_scalp/web/auth.py``). Binding the
+default 127.0.0.1 keeps the trust boundary identical to the engine's own;
+``--allow-remote`` deliberately prints a loud warning because it exposes an
+unauthenticated, TLS-less path to the control plane.
+
+Realtime
+--------
+``/api/ticks/stream`` (and ANY upstream ``text/event-stream`` response) is
+relayed TRUE passthrough: read up to 64 KiB of already-decoded bytes
+(``HTTPResponse.read1``), write, flush, repeat — no line buffering, no
+aggregation, no compression applied. A client that goes away closes the
+upstream connection immediately.
+
+Run (repo root):
+    ./.venv/Scripts/python.exe scripts/serve_alt_ui.py
+    ./.venv/Scripts/python.exe scripts/serve_alt_ui.py --port 8088 \
+        --backend http://127.0.0.1:8080 --dist frontend/dist
+Test:
+    ./.venv/Scripts/python.exe -m pytest -p no:cacheprovider \
+        tests/unit/test_alt_ui_standalone_server.py
+Docs: scripts/README-alt-ui.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import socket
+import sys
+import uuid
+from dataclasses import dataclass
+from http.client import HTTPConnection, IncompleteRead
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+LOGGER = logging.getLogger("nse.alt_ui")
+#: Neutral default handler so importing this module never crashes a logging
+#: config; ``main()`` installs the real StreamHandler.
+LOGGER.addHandler(logging.NullHandler())
+
+#: Path prefixes ALWAYS proxied to the backend — never served locally, never
+#: SPA-fallback'd, never cached (mirrors frontend/vite.config.ts proxy keys).
+API_PREFIXES: tuple[str, ...] = ("/api", "/health", "/healthz")
+
+#: The realtime route (detection is content-type driven; this is a path
+#: override so an empty/streaming-starting upstream is still relayed raw).
+SSE_PATHS: frozenset[str] = frozenset({"/api/ticks/stream"})
+
+#: Request headers forwarded upstream. Everything else is dropped, including
+#: every hop-by-hop header (this host never forwards more than it needs to).
+FORWARD_REQUEST_HEADERS: frozenset[str] = frozenset(
+    {"content-type", "accept", "x-nse-token", "cookie", "authorization"}
+)
+
+#: Correlation header: accepted from the client, always sent upstream, always
+#: echoed on responses (same plumbing/shape as web/errors.request_id_from_request).
+REQUEST_ID_HEADER = "X-Request-ID"
+
+#: Hop-by-hop response headers that are never re-emitted (RFC 9110 §7.6.1):
+#: this host re-frames every response itself (content-length, or close-delimited
+#: for SSE).
+HOP_BY_HOP_RESPONSE_HEADERS: frozenset[str] = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+#: Upload guard for proxied request bodies (engine payloads are tiny JSON).
+MAX_REQUEST_BODY_BYTES = 1 * 1024 * 1024  # 1 MiB
+#: Max bytes per raw relay read on the SSE path (bounds per-chunk latency).
+SSE_READ_SIZE = 64 * 1024
+#: Buffered (non-SSE) upstream read timeout unless NSE_ALT_UI_PROXY_TIMEOUT.
+DEFAULT_PROXY_TIMEOUT = 300.0
+
+#: Vite content-hash suffix (e.g. index-Dgg7nCdr.js) -> immutable caching.
+_ASSET_HASH_RE = re.compile(r"-[A-Za-z0-9_]{8,}\.[A-Za-z0-9]+$")
+
+CONTENT_TYPES: dict[str, str] = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json",
+    ".map": "application/json",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".txt": "text/plain; charset=utf-8",
+}
+
+#: The built bundle uses vite ``base: "/alt/"``; on this standalone host the
+#: same dist is mounted at root, so a leading ``/alt`` path segment is
+#: transparently stripped (``/alt/assets/x.js`` -> ``assets/x.js``).
+APP_BASE_PREFIX = "alt"
+
+_LOCALHOST_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def new_request_id() -> str:
+    """Correlation id, same shape as nexus_scalp.web.errors.new_request_id."""
+    return "req_" + uuid.uuid4().hex[:10]
+
+
+def redact_url(url: str) -> str:
+    """Strip credential-bearing query params from a URL for logging.
+
+    ``?token=`` is an accepted WEB-AUTH-P0 transport (EventSource cannot set
+    headers), so it must never reach a log line intact.
+    """
+    return re.sub(
+        r"(?i)([?&](?:token|access_token)=)[^&#\s\"']*",
+        r"\1[REDACTED]",
+        url,
+    )
+
+
+def redact_header_value(name: str, value: str) -> str:
+    """Never log credentials: emit shape only for sensitive headers."""
+    n = name.strip().lower()
+    if n in ("authorization", "cookie", "x-nse-token", "proxy-authorization"):
+        return f"[REDACTED:{n} len={len(value)}]"
+    return value
+
+
+def _is_sse_content_type(value: str | None) -> bool:
+    return "text/event-stream" in (value or "").lower()
+
+
+@dataclass(frozen=True)
+class BackendTarget:
+    """Parsed reverse-proxy upstream (http only — TLS is out of scope for
+    this host; see scripts/README-alt-ui.md limitations)."""
+
+    host: str
+    port: int
+
+    @property
+    def netloc(self) -> str:
+        return f"{self.host}:{self.port}"
+
+    @property
+    def origin(self) -> str:
+        return f"http://{self.netloc}"
+
+
+def parse_backend_url(url: str) -> BackendTarget:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"backend must be an http(s):// URL, got: {url!r}")
+    if parsed.scheme == "https":
+        raise ValueError(
+            f"TLS to the backend is out of scope for this stdlib host "
+            f"(keep it localhost): got {url!r}"
+        )
+    host = parsed.hostname
+    if not host:
+        raise ValueError(f"backend URL has no host: {url!r}")
+    port = parsed.port or 80
+    return BackendTarget(host=host, port=int(port))
+
+
+# ---------------------------------------------------------------------------
+# request handler
+# ---------------------------------------------------------------------------
+class AltUIRequestHandler(BaseHTTPRequestHandler):
+    """Static dist server + API reverse proxy for one (dist, backend) pair.
+
+    Instantiate through :func:`build_server` — it binds the configuration into
+    a handler subclass. Never reuse the raw class without setting
+    ``dist_root`` / ``backend``.
+    """
+
+    protocol_version = "HTTP/1.1"
+    server_version = "nse-alt-ui"
+    sys_version = ""
+
+    # bound by build_server()
+    dist_root: Path
+    backend: BackendTarget
+    api_prefixes: tuple[str, ...] = API_PREFIXES
+
+    _request_id: str = "-"
+
+    # ------------------------------------------------------------- dispatch
+    def do_GET(self) -> None:
+        self._dispatch("GET")
+
+    def do_HEAD(self) -> None:
+        self._dispatch("HEAD")
+
+    def do_POST(self) -> None:
+        self._dispatch("POST")
+
+    def do_PUT(self) -> None:
+        self._dispatch("PUT")
+
+    def do_PATCH(self) -> None:
+        self._dispatch("PATCH")
+
+    def do_DELETE(self) -> None:
+        self._dispatch("DELETE")
+
+    def do_OPTIONS(self) -> None:
+        self._dispatch("OPTIONS")
+
+    def _dispatch(self, method: str) -> None:
+        raw_path = self.path or "/"
+        raw_only, _, query = raw_path.partition("?")
+        self._request_id = (self.headers.get("x-request-id") or "").strip()[:64] or new_request_id()
+
+        # Traversal guard applies to EVERY route (proxy included): a path
+        # containing '..' (literal or encoded) or backslashes is a scan/bypass
+        # attempt, not a legitimate request on this surface. Answer 404 (the
+        # fail-closed envelope) so scanners learn nothing about why, and log
+        # the rejection loudly with a redacted path.
+        if not self._path_is_clean(raw_only):
+            LOGGER.warning(
+                "rejected suspicious path method=%s path=%s request_id=%s",
+                method,
+                redact_url(raw_path)[:160],
+                self._request_id,
+            )
+            self._send_error_envelope(404, "RESOURCE_NOT_FOUND", "not found")
+            return
+
+        if self._is_api_path(raw_only):
+            self._proxy(method, raw_only, query)
+        else:
+            self._serve_static(method, raw_only)
+
+    @classmethod
+    def _is_api_path(cls, raw_only: str) -> bool:
+        # Case-sensitive on purpose: /API/status is not a backend route.
+        return any(raw_only == p or raw_only.startswith(p + "/") for p in cls.api_prefixes)
+
+    @staticmethod
+    def _path_is_clean(raw_only: str) -> bool:
+        """Reject encoded + literal traversal before any filesystem/proxy work.
+
+        Decodes up to two rounds so double-encoded (%252e%252e) payloads are
+        caught too. Rejects NUL and backslashes. This mirrors (and does not
+        contradict) the backend's own traversal refusal in auth.is_public_path.
+        """
+        if not raw_only:
+            return False
+        decoded = raw_only
+        for _ in range(2):
+            nxt = unquote(decoded)
+            if nxt == decoded:
+                break
+            decoded = nxt
+        if ".." in raw_only or ".." in decoded:
+            return False
+        if "\\" in raw_only or "\\" in decoded or "\x00" in decoded:
+            return False
+        return True
+
+    # -------------------------------------------------------- static (dist)
+    def _serve_static(self, method: str, raw_only: str) -> None:
+        if method not in ("GET", "HEAD"):
+            self._send_error_envelope(405, "BAD_REQUEST", "method not allowed for static paths")
+            return
+        rel = unquote(raw_only).lstrip("/")
+        # /alt, /alt/ and /alt/... address the same bundle root the vite build
+        # assumes (base "/alt/").
+        if rel == APP_BASE_PREFIX or rel.startswith(APP_BASE_PREFIX + "/"):
+            rel = rel[len(APP_BASE_PREFIX) :].lstrip("/")
+        if rel in ("", "index.html"):
+            self._send_static_file(self.dist_root / "index.html", head_only=method == "HEAD")
+            return
+        candidate = self._resolve_under_dist(rel)
+        if candidate is None:
+            # SPA fallback: an unknown non-API path that accepts HTML is a
+            # client-side route (e.g. /positions deep link) -> index.html.
+            if "text/html" in (self.headers.get("accept") or "").lower():
+                self._send_static_file(self.dist_root / "index.html", head_only=method == "HEAD")
+                return
+            self._send_error_envelope(404, "RESOURCE_NOT_FOUND", "not found")
+            return
+        self._send_static_file(candidate, head_only=method == "HEAD")
+
+    def _resolve_under_dist(self, rel: str) -> Path | None:
+        """Resolve ``rel`` strictly INSIDE dist_root.
+
+        Refuses: escapes (realpath + commonpath — covers ../, encoded ../,
+        symlink/junction escapes, drive changes on Windows), directories
+        (NO directory listing, ever), and anything that is not a regular file.
+        """
+        root = self.dist_root.resolve()
+        try:
+            resolved = (root / rel).resolve()
+        except OSError:  # pragma: no cover - exotic filesystem error
+            return None
+        try:
+            if os.path.commonpath([str(root), str(resolved)]) != str(root):
+                return None
+        except ValueError:  # different drives / UNC edge on Windows
+            return None
+        if resolved == root or not resolved.is_file():
+            return None
+        return resolved
+
+    def _send_static_file(self, path: Path, *, head_only: bool) -> None:
+        try:
+            rel = str(path.relative_to(self.dist_root))
+        except ValueError:  # pragma: no cover - defensive: never serve outside
+            self._send_error_envelope(404, "RESOURCE_NOT_FOUND", "not found")
+            return
+        resolved = self._resolve_under_dist(rel)
+        if resolved is None:  # pragma: no cover - defensive double guard
+            self._send_error_envelope(404, "RESOURCE_NOT_FOUND", "not found")
+            return
+        try:
+            body = resolved.read_bytes()
+        except OSError:
+            self._send_error_envelope(404, "RESOURCE_NOT_FOUND", "not found")
+            return
+        ctype = CONTENT_TYPES.get(resolved.suffix.lower(), "application/octet-stream")
+        is_index = resolved.name == "index.html"
+        self.send_response(200)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        if is_index:
+            self.send_header("Cache-Control", "no-store")
+        elif self._is_hashed_asset(resolved):
+            # content-hashed filenames under /assets/ are immutable forever
+            self.send_header("Cache-Control", "max-age=31536000, immutable")
+        else:
+            self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header(REQUEST_ID_HEADER, self._request_id)
+        self.end_headers()
+        if not head_only:
+            self.wfile.write(body)
+
+    def _is_hashed_asset(self, path: Path) -> bool:
+        """dist/assets/<name>-<contenthash>.<ext> -> safe to pin forever."""
+        try:
+            under_assets = "assets" in path.relative_to(self.dist_root.resolve()).parts
+        except ValueError:
+            under_assets = False
+        return under_assets and bool(_ASSET_HASH_RE.search(path.name))
+
+    # ------------------------------------------------------------- proxying
+    def _proxy(self, method: str, raw_path: str, query: str) -> None:
+        request_id = self._request_id
+        target_path = raw_path + (("?" + query) if query else "")
+        body = self._read_request_body()
+        if body is None:  # oversized / un-framable -> error response sent
+            return
+        conn: HTTPConnection | None = None
+        stream = False
+        started = False
+        try:
+            conn = HTTPConnection(
+                self.backend.host, self.backend.port, timeout=self._proxy_timeout()
+            )
+            conn.putrequest(method, target_path, skip_host=True, skip_accept_encoding=True)
+            forwarded_names = set()
+            for name in self.headers:
+                lname = name.lower()
+                if lname in FORWARD_REQUEST_HEADERS:
+                    conn.putheader(name, self.headers[name])
+                    forwarded_names.add(lname)
+            if body and "content-type" not in forwarded_names:
+                conn.putheader("Content-Type", "application/json")
+            if body:
+                conn.putheader("Content-Length", str(len(body)))
+            conn.putheader(REQUEST_ID_HEADER, request_id)
+            conn.putheader("Host", self.backend.netloc)
+            conn.endheaders()  # (stdlib name — not end_headers)
+            if body:
+                conn.send(body)
+            resp = conn.getresponse()
+            started = True
+            stream = _is_sse_content_type(resp.getheader("content-type")) or (raw_path in SSE_PATHS)
+            self._relay(resp, stream=stream)
+        except (OSError, IncompleteRead) as exc:
+            if stream:
+                # Mid-stream upstream death: the client sees the event stream
+                # close and the UI's EventSource reconnects. Nothing to frame.
+                LOGGER.info(
+                    "proxy stream ended method=%s path=%s request_id=%s err=%s",
+                    method,
+                    redact_url(target_path),
+                    request_id,
+                    type(exc).__name__,
+                )
+                self.close_connection = True
+            elif started:
+                # Headers already reached the client: all we can do is drop
+                # the connection (client sees a truncated response).
+                LOGGER.error(
+                    "proxy relay broke method=%s path=%s request_id=%s err=%s",
+                    method,
+                    redact_url(target_path),
+                    request_id,
+                    type(exc).__name__,
+                )
+                self.close_connection = True
+            else:
+                self._fail_closed(method, target_path, exc)
+        except Exception as exc:  # pragma: no cover - defensive, fail closed
+            if not started:
+                self._fail_closed(method, target_path, exc)
+            else:  # pragma: no cover
+                LOGGER.exception("proxy post-response failure request_id=%s", request_id)
+                self.close_connection = True
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except OSError:
+                    pass
+
+    @staticmethod
+    def _proxy_timeout() -> float:
+        env = os.environ.get("NSE_ALT_UI_PROXY_TIMEOUT", "").strip()
+        try:
+            return float(env) if env else DEFAULT_PROXY_TIMEOUT
+        except ValueError:
+            return DEFAULT_PROXY_TIMEOUT
+
+    def _read_request_body(self) -> bytes | None:
+        """Content-Length-bounded body read.
+
+        Returns None when an error response was already emitted (413 over the
+        guard / 400 un-framable). Never streams an unbounded upload.
+        """
+        if self.command not in ("POST", "PUT", "PATCH", "DELETE"):
+            return b""
+        if "chunked" in (self.headers.get("transfer-encoding") or "").lower():
+            self.close_connection = True  # unread body: kill the keep-alive
+            self._send_error_envelope(
+                400, "BAD_REQUEST", "chunked request bodies are not supported"
+            )
+            return None
+        raw_len = self.headers.get("content-length")
+        try:
+            length = int(raw_len) if raw_len is not None else 0
+        except ValueError:
+            self.close_connection = True
+            self._send_error_envelope(400, "BAD_REQUEST", "invalid content-length")
+            return None
+        if length > MAX_REQUEST_BODY_BYTES:
+            # Do NOT read the body (that is the DoS point); answer + close.
+            self.close_connection = True
+            self._send_error_envelope(
+                413,
+                "PAYLOAD_TOO_LARGE",
+                f"request body exceeds the {MAX_REQUEST_BODY_BYTES}-byte proxy guard",
+            )
+            return None
+        if length <= 0:
+            return b""
+        try:
+            return self.rfile.read(length)
+        except OSError:  # pragma: no cover - client vanished mid-upload
+            self.close_connection = True
+            return None
+
+    def _relay(self, resp, *, stream: bool) -> None:  # resp: HTTPResponse
+        """Relay the upstream response, re-framed for HTTP/1.1."""
+        headers: list[tuple[str, str]] = [
+            (name, value)
+            for name, value in resp.getheaders()
+            if name.lower() not in HOP_BY_HOP_RESPONSE_HEADERS
+        ]
+        names_lower = {n.lower() for n, _ in headers}
+
+        if stream:
+            self.send_response(resp.status)
+            for name, value in headers:
+                if name.lower() in ("content-length", "date", "server"):
+                    continue  # this host re-frames; body ends at connection close
+                self.send_header(name, value)
+            if "cache-control" not in names_lower:
+                self.send_header("Cache-Control", "no-cache")
+            if "x-accel-buffering" not in names_lower:
+                self.send_header("X-Accel-Buffering", "no")
+            self.send_header(REQUEST_ID_HEADER, self._request_id)
+            # close-delimited body (we stripped transfer-encoding)
+            self.send_header("Connection", "close")
+            self.close_connection = True
+            self.end_headers()
+            self._relay_sse(resp)
+            return
+
+        body = resp.read()  # buffered: content-length is corrected exactly
+        self.send_response(resp.status)
+        for name, value in headers:
+            if name.lower() in ("content-length", "date", "server"):
+                continue  # re-emitted/corrected by this host
+            self.send_header(name, value)
+        if self.command == "HEAD":
+            # No body to measure: keep the upstream's declared length.
+            upstream_len = resp.getheader("content-length")
+            if upstream_len is not None:
+                self.send_header("Content-Length", upstream_len)
+        elif resp.status not in (204, 304):
+            # 204/304 must not carry content-length (RFC 9110 §15.3.2/§15.4.5)
+            self.send_header("Content-Length", str(len(body)))
+        if REQUEST_ID_HEADER.lower() not in names_lower:
+            self.send_header(REQUEST_ID_HEADER, self._request_id)
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _relay_sse(self, resp) -> None:  # resp: HTTPResponse
+        """TRUE SSE passthrough: one raw read (<= 64 KiB) -> one write -> flush.
+
+        Whatever byte framing the backend used (event frames, comment
+        keepalives) reaches the browser the moment it hits this wire. A dead
+        client socket stops the relay, which closes the upstream connection
+        (``finally`` in :meth:`_proxy`).
+        """
+        sock = getattr(self.connection, "sock", None)
+        if sock is not None:
+            try:
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            except OSError:  # pragma: no cover
+                pass
+        try:
+            while True:
+                try:
+                    chunk = resp.read1(SSE_READ_SIZE)
+                except TimeoutError:
+                    # Idle upstream. A real engine emits SSE keepalives every
+                    # few seconds, so a comment ping here is redundant
+                    # traffic — but it is what lets us NOTICE a dead client
+                    # while the upstream is silent (disconnect detection must
+                    # not wait for the next data frame, which could be the
+                    # next trade tick that never comes on a halted engine).
+                    try:
+                        self.wfile.write(b":\n\n")
+                        self.wfile.flush()
+                        continue
+                    except OSError:
+                        LOGGER.info(
+                            "sse client disconnected on keepalive request_id=%s",
+                            self._request_id,
+                        )
+                        self.close_connection = True
+                        return
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except OSError:
+            LOGGER.info("sse client disconnected request_id=%s", self._request_id)
+            self.close_connection = True
+        except IncompleteRead as exc:  # upstream died mid-body
+            if exc.partial:
+                try:
+                    self.wfile.write(exc.partial)
+                    self.wfile.flush()
+                except OSError:  # pragma: no cover
+                    pass
+            self.close_connection = True
+
+    def _fail_closed(self, method: str, path: str, exc: BaseException) -> None:
+        """Backend unreachable -> 502 v1-style envelope. NEVER a local
+        fallback, NEVER a cached answer, NEVER an exception leak."""
+        LOGGER.error(
+            "BACKEND_UNREACHABLE method=%s path=%s request_id=%s backend=%s err=%s: %.200s",
+            method,
+            redact_url(path),
+            self._request_id,
+            self.backend.origin,
+            type(exc).__name__,
+            exc,
+        )
+        self._send_error_envelope(
+            502,
+            "BACKEND_UNREACHABLE",
+            f"engine backend unreachable at {self.backend.origin}",
+        )
+
+    # ------------------------------------------------------------ plumbing
+    def _send_error_envelope(self, status: int, code: str, message: str) -> None:
+        """Public-safe error body, same envelope style as web/errors.
+        safe_error_payload ({"error": {code, message, request_id}} + legacy
+        available/success booleans); internals go to logs only."""
+        rid = self._request_id
+        payload = {
+            "ok": False,
+            "available": False,
+            "success": False,
+            "error": {"code": code, "message": message, "request_id": rid},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        try:
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.send_header(REQUEST_ID_HEADER, rid)
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body)
+        except OSError:  # pragma: no cover - client already gone
+            self.close_connection = True
+
+    def log_request(self, code: str | int = "-", size: str | int = "-") -> None:
+        """One access line per response — WITHOUT any credential material.
+
+        ``self.path`` can carry ``?token=`` (accepted SSE transport) so it is
+        redacted; header VALUES (Authorization / Cookie / X-NSE-Token) are
+        never logged at all (redact_header_value exists for debug dumps).
+        """
+        LOGGER.info(
+            "%s %s -> %s (%s) request_id=%s",
+            self.command,
+            redact_url(self.path or "-"),
+            code,
+            size,
+            getattr(self, "_request_id", "-"),
+        )
+
+    def log_error(self, fmt: str, *args) -> None:
+        LOGGER.warning(fmt % args)
+
+    def log_message(self, fmt: str, *args) -> None:  # pragma: no cover
+        LOGGER.debug(redact_url(fmt % args))
+
+
+# ---------------------------------------------------------------------------
+# server construction
+# ---------------------------------------------------------------------------
+class AltUIServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer that keeps TCP teardown races off stderr.
+
+    A browser (or a test client) closing a keep-alive/SSE connection between
+    requests is NORMAL and surfaces as ConnectionResetError/Abort inside the
+    handler thread; the stdlib prints a full traceback for it. Real errors are
+    still reported.
+    """
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def handle_error(self, request, client_address) -> None:
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionError, TimeoutError)):
+            LOGGER.debug("connection aborted by %s: %s", client_address, exc)
+            return
+        super().handle_error(request, client_address)
+
+
+def build_server(
+    dist_dir: str | os.PathLike[str],
+    backend: BackendTarget,
+    listen: tuple[str, int] = ("127.0.0.1", 8088),
+) -> AltUIServer:
+    """Create (do NOT start) the alt-console host; call ``serve_forever()``.
+
+    ``listen`` defaults to loopback on purpose (auth model above). Tests pass
+    port 0 and read back ``server_address``.
+    """
+    root = Path(dist_dir).resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(
+            f"dist directory not found: {root} — build the UI first "
+            f"(cd frontend && npm run build) or pass --dist / NEXUS_ALT_UI_DIR"
+        )
+
+    handler_cls = type(
+        "ConfiguredAltUIHandler",
+        (AltUIRequestHandler,),
+        {"dist_root": root, "backend": backend},
+    )
+    return AltUIServer(listen, handler_cls)
+
+
+def _default_dist() -> Path:
+    return Path(__file__).resolve().parents[1] / "frontend" / "dist"
+
+
+_REMOTE_WARNING = """\
+********************************************************************************
+* NSE ALT-UI HOST IS BOUND TO A NON-LOCALHOST ADDRESS ({host})
+*
+* The auth model: this host enforces NOTHING. Static SPA files go to anyone
+* who can connect; every /api call is forwarded with the caller's Bearer /
+* X-NSE-Token / nse_web_auth cookie to the engine backend UNCHECKED. That is
+* safe only where the backend's own bind is safe. There is NO TLS here, so
+* tokens cross the network in cleartext. Never combine with LIVE execution
+* mode or an untrusted network. The engine's WEB-AUTH-P0 stays the only
+* authentication layer in this design.
+********************************************************************************"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="serve_alt_ui",
+        description="Standalone alt-console host: static frontend/dist plus a "
+        "reverse proxy for /api /health /healthz to the NSE engine backend "
+        "(stdlib only, SSE passthrough, fail-closed).",
+    )
+    parser.add_argument("--port", type=int, default=8088, help="listen port (default 8088)")
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="bind address (default 127.0.0.1; --allow-remote selects 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--backend",
+        default=None,
+        help="engine backend origin to proxy /api /health /healthz to "
+        "(default http://127.0.0.1:8080; NSE_API_ORIGIN env fallback, same "
+        "knob the vite dev proxy uses)",
+    )
+    parser.add_argument(
+        "--dist",
+        default=None,
+        help="built UI directory (default <repo>/frontend/dist; "
+        "NEXUS_ALT_UI_DIR env fallback, same knob the /alt mount uses)",
+    )
+    parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="bind 0.0.0.0 instead of 127.0.0.1 (OFF by default; prints a "
+        "loud auth-model warning — see README-alt-ui.md)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="debug logging")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    backend_url = args.backend or os.environ.get("NSE_API_ORIGIN") or "http://127.0.0.1:8080"
+    dist_arg = args.dist or os.environ.get("NEXUS_ALT_UI_DIR") or str(_default_dist())
+    try:
+        backend = parse_backend_url(backend_url)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+    host = args.host or ("0.0.0.0" if args.allow_remote else "127.0.0.1")
+    try:
+        httpd = build_server(dist_arg, backend, listen=(host, args.port))
+    except FileNotFoundError as exc:
+        LOGGER.error("%s", exc)
+        return 2
+    except OSError as exc:
+        LOGGER.error("cannot bind %s:%s — %s", host, args.port, exc)
+        return 2
+
+    bound_host, bound_port = httpd.server_address[0], httpd.server_address[1]
+    if bound_host not in _LOCALHOST_HOSTS:
+        print(_REMOTE_WARNING.format(host=bound_host), file=sys.stderr, flush=True)
+    handler = httpd.RequestHandlerClass
+    LOGGER.info("[ALT-UI] standalone console on http://%s:%d", bound_host, bound_port)
+    LOGGER.info("[ALT-UI] dist=%s backend=%s", handler.dist_root, backend.origin)  # type: ignore[attr-defined]
+    LOGGER.info(
+        "[ALT-UI] proxied prefixes=%s; SSE /api/ticks/stream relayed unbuffered; "
+        "static SPA fallback at /alt and /",
+        " ".join(API_PREFIXES),
+    )
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        LOGGER.info("[ALT-UI] interrupted — shutting down")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+    return 0
+
+
+#: Import-time paranoia probe: the guard must refuse the classic vectors. A
+#: regression guard against someone "simplifying" _path_is_clean away.
+_TRAVEL_CHECKS = (
+    "/..%2f..%2fWindows/win.ini",
+    "/%2e%2e/%2e%2e/etc/passwd",
+    "/%252e%252e/etc/passwd",
+    "/a\\..\\b",
+    "/../../x",
+)
+for _vec in _TRAVEL_CHECKS:
+    if AltUIRequestHandler._path_is_clean(_vec.partition("?")[0]):
+        raise RuntimeError(f"traversal guard FAILED for {_vec}")
+del _vec
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_alt_ui_standalone_server.py
+++ b/tests/unit/test_alt_ui_standalone_server.py
@@ -1,0 +1,719 @@
+"""STANDALONE-ALT-UI (BACKEND-1 lane): routing, traversal, SSE-flush and
+fail-closed behavior of ``scripts/serve_alt_ui.py`` — fully offline against a
+stub upstream (``http.server``) and a temp dist dir. No engine, no network.
+
+Run (repo root):
+  ./.venv/Scripts/python.exe -m pytest -p no:cacheprovider ^
+      tests/unit/test_alt_ui_standalone_server.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import serve_alt_ui as alt  # noqa: E402
+
+TOKEN = "s3cr3t-web-auth-token-abc123"
+BEARER = "s3cr3t-bearer-value-xyz789"
+
+
+# ---------------------------------------------------------------------------
+# stub upstream
+# ---------------------------------------------------------------------------
+class _StubHandler(BaseHTTPRequestHandler):
+    """Minimal engine stand-in: JSON echo, SSE stream, 401 route, chunked JSON.
+
+    Per-instance state lives on ``self.server`` (``requests`` log,
+    ``disconnect_seen`` event) so each test env is hermetic.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    # ------------------------------------------------------------- helpers
+    def _json(self, status: int, payload: dict, extra_headers: dict | None = None) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (extra_headers or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    # ------------------------------------------------------------- routes
+    def do_GET(self) -> None:
+        path, _, query = self.path.partition("?")
+        self.server.requests.append(  # type: ignore[attr-defined]
+            {
+                "method": "GET",
+                "path": self.path,
+                "headers": {k.lower(): v for k, v in self.headers.items()},
+            }
+        )
+        if path == "/api/ticks/stream":
+            self._sse(query)
+            return
+        if path == "/api/private":
+            self._json(
+                401,
+                {"ok": False, "error": {"code": "UNAUTHORIZED", "message": "no token"}},
+                {"WWW-Authenticate": "Bearer"},
+            )
+            return
+        if path == "/api/chunked-json":
+            body = json.dumps({"chunked": True}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.end_headers()
+            half = len(body) // 2
+            for part in (body[:half], body[half:]):
+                self.wfile.write(b"%x\r\n" % len(part) + part + b"\r\n")
+            self.wfile.write(b"0\r\n\r\n")
+            return
+        if path == "/api/status":
+            self._json(
+                200,
+                {
+                    "state_version": 7,
+                    "auth": self.headers.get("authorization"),
+                    "x_nse_token": self.headers.get("x-nse-token"),
+                    "cookie": self.headers.get("cookie"),
+                    "request_id": self.headers.get("x-request-id"),
+                    "query": query,
+                },
+            )
+            return
+        if path in ("/health", "/healthz"):
+            self._json(200, {"status": "ok", "path": path})
+            return
+        self._json(404, {"ok": False, "error": {"code": "RESOURCE_NOT_FOUND"}})
+
+    def do_HEAD(self) -> None:
+        self.server.requests.append(  # type: ignore[attr-defined]
+            {"method": "HEAD", "path": self.path, "headers": {}}
+        )
+        body = b'{"ok":true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length", "0"))
+        raw = self.rfile.read(length) if length else b""
+        self.server.requests.append(  # type: ignore[attr-defined]
+            {
+                "method": "POST",
+                "path": self.path,
+                "headers": {k.lower(): v for k, v in self.headers.items()},
+                "body": raw.decode("utf-8", "replace"),
+            }
+        )
+        self._json(200, {"echo_ct": self.headers.get("content-type"), "got": raw.decode()})
+
+    def _sse(self, query: str) -> None:
+        params = dict(p.split("=", 1) for p in query.split("&") if "=" in p)
+        n_frames = int(params.get("frames", "3"))
+        gap = float(params.get("gap", "0.30"))
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        self._stream_broken = False
+
+        def _write(data: bytes) -> None:
+            # Once ANY write fails (the downstream proxy hung up), every
+            # further write fails too — but recv() would just sit in its
+            # timeout, so short-circuit the producer loop instead.
+            if self._stream_broken:
+                raise ConnectionError("stream already marked broken")
+            try:
+                self.wfile.write(data)
+                self.wfile.flush()
+            except OSError as exc:
+                self._stream_broken = True
+                raise ConnectionError(f"downstream gone: {exc}") from exc
+
+        try:
+            for i in range(n_frames):
+                frame = f'event: tick\ndata: {{"state_version": {i}}}\n\n'.encode()
+                _write(b"%x\r\n" % len(frame) + frame + b"\r\n")
+                time.sleep(gap)
+            _write(b"0\r\n\r\n")
+        except (OSError, ValueError, ConnectionError):
+            # the proxy hung up on us (client disconnect chain) — detecting
+            # THIS is exactly what one test asserts.
+            self.server.disconnect_seen.set()  # type: ignore[attr-defined]
+
+    def log_message(self, fmt: str, *args) -> None:  # keep pytest output clean
+        pass
+
+
+class _QuietStubServer(ThreadingHTTPServer):
+    """The disconnect test makes the stub's SSE write fail on purpose; the
+    stdlib prints that traceback to stderr (ugly + alarming in test logs).
+    The stub records the event via ``disconnect_seen`` instead."""
+
+    def handle_error(self, request, client_address) -> None:
+        exc = sys.exc_info()[1]
+        if not isinstance(exc, (ConnectionError, OSError)):
+            super().handle_error(request, client_address)
+
+
+# ---------------------------------------------------------------------------
+# environment fixture
+# ---------------------------------------------------------------------------
+class _Env:
+    def __init__(self, base: str, stub: ThreadingHTTPServer, host: ThreadingHTTPServer):
+        self.base = base
+        self.stub = stub
+        self.host = host
+
+    # ----------------------------------------------------------- plumbing
+    def http(
+        self, path: str, headers: dict | None = None, method: str = "GET", data: bytes | None = None
+    ):
+        req = Request(self.base + path, headers=headers or {}, method=method, data=data)
+        try:
+            resp = urlopen(req, timeout=15)
+        except HTTPError as e:
+            return e
+        return resp
+
+    def fetch(
+        self, path: str, headers: dict | None = None, method: str = "GET", data: bytes | None = None
+    ):
+        """-> (status, {lower: header}, body bytes)"""
+        resp = self.http(path, headers, method, data)
+        with resp:
+            return resp.status, {k.lower(): v for k, v in resp.headers.items()}, resp.read()
+
+    def raw(self, request_bytes: bytes, read_until_close: bool = False, timeout: float = 15.0):
+        """Send a literal request, return all bytes received (headers raw —
+        needed to prove per-chunk arrival timing and header stripping)."""
+        hostport = self.base.split("://", 1)[1]
+        host, port = hostport.rsplit(":", 1)
+        sock = socket.create_connection((host, int(port)), timeout=timeout)
+        try:
+            sock.sendall(request_bytes)
+            chunks: list[bytes] = []
+            if read_until_close:
+                while True:
+                    try:
+                        part = sock.recv(65536)
+                    except OSError:
+                        break
+                    if not part:
+                        break
+                    chunks.append(part)
+            else:
+                chunks.append(sock.recv(65536))
+            return b"".join(chunks)
+        finally:
+            sock.close()
+
+    @property
+    def requests(self) -> list[dict]:
+        return self.stub.requests  # type: ignore[attr-defined]
+
+
+def _make_dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text("<!doctype html><title>NSE Alt</title><div id=root></div>")
+    (dist / "assets" / "index-Dgg7nCdr.js").write_text("console.log('nse');")
+    (dist / "assets" / "index-BQKTd2Zu.css").write_text("body{color:red}")
+    (dist / "assets" / "plain.css").write_text("a{}")
+    (dist / "logo.svg").write_text("<svg xmlns='http://www.w3.org/2000/svg'/>")
+    (dist / "favicon.ico").write_bytes(b"\x00\x00\x01\x00")
+    # decoy: a file UNDER dist named like an API route — proves the proxy
+    # never answers API requests from disk.
+    (dist / "api").mkdir()
+    (dist / "api" / "status").write_text('{"FROM_DISK":true}')
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("TOP-SECRET-OUTSIDE-DIST")
+    return dist
+
+
+def _start(tmp_path: Path) -> _Env:
+    dist = _make_dist(tmp_path)
+    stub = _QuietStubServer(("127.0.0.1", 0), _StubHandler)
+    stub.daemon_threads = True  # type: ignore[attr-defined]
+    stub.requests = []  # type: ignore[attr-defined]
+    stub.disconnect_seen = threading.Event()  # type: ignore[attr-defined]
+    threading.Thread(target=stub.serve_forever, daemon=True).start()
+    backend = alt.BackendTarget("127.0.0.1", stub.server_address[1])
+    host = alt.build_server(dist, backend, listen=("127.0.0.1", 0))
+    threading.Thread(target=host.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{host.server_address[1]}"
+    return _Env(base, stub, host)
+
+
+@pytest.fixture()
+def env(tmp_path: Path):
+    e = _start(tmp_path)
+    yield e
+    e.host.shutdown()
+    e.host.server_close()
+    e.stub.shutdown()
+    e.stub.server_close()
+
+
+# ---------------------------------------------------------------------------
+# static routing
+# ---------------------------------------------------------------------------
+class TestStaticRouting:
+    def test_index_served_at_root_and_alt(self, env: _Env) -> None:
+        for path in ("/", "/alt", "/alt/", "/index.html"):
+            status, headers, body = env.fetch(path)
+            assert status == 200, path
+            assert b"NSE Alt" in body
+            assert headers["content-type"].startswith("text/html")
+            assert headers["cache-control"] == "no-store"
+            assert headers["x-request-id"].startswith("req_")
+
+    def test_asset_mime_and_immutable_caching(self, env: _Env) -> None:
+        status, headers, body = env.fetch("/assets/index-Dgg7nCdr.js")
+        assert status == 200
+        assert headers["content-type"].startswith("text/javascript")
+        assert headers["cache-control"] == "max-age=31536000, immutable"
+        assert b"nse" in body
+        _s, css, _b = env.fetch("/assets/index-BQKTd2Zu.css")
+        assert css["content-type"].startswith("text/css")
+        # non-hashed file: must NOT get the immutable pin
+        _s, plain, _b = env.fetch("/assets/plain.css")
+        assert plain["cache-control"] == "no-store"
+        _s, svg, _b = env.fetch("/logo.svg")
+        assert svg["content-type"] == "image/svg+xml"
+        _s, ico, _b = env.fetch("/favicon.ico")
+        assert ico["content-type"] == "image/x-icon"
+
+    def test_spa_fallback_on_deep_link(self, env: _Env) -> None:
+        # the Positions page deep link: unknown path + Accept: text/html
+        status, headers, body = env.fetch("/positions", headers={"Accept": "text/html"})
+        assert status == 200
+        assert headers["content-type"].startswith("text/html")
+        assert b"NSE Alt" in body
+        # same with the vite base prefix
+        status, _h, body = env.fetch("/alt/positions", headers={"Accept": "text/html"})
+        assert status == 200 and b"NSE Alt" in body
+
+    def test_unknown_path_without_html_accept_is_404(self, env: _Env) -> None:
+        status, headers, body = env.fetch("/nope/nothing", headers={"Accept": "application/json"})
+        assert status == 404
+        assert "text/html" not in headers.get("content-type", "")
+        payload = json.loads(body)
+        assert payload["error"]["code"] == "RESOURCE_NOT_FOUND"
+        assert payload["error"]["request_id"]
+
+    def test_no_directory_listing(self, env: _Env) -> None:
+        status, _h, body = env.fetch("/assets", headers={"Accept": "application/json"})
+        assert status == 404
+        assert b"index-Dgg7nCdr.js" not in body
+        status2, _h2, body2 = env.fetch("/nonexistent", headers={"Accept": "application/json"})
+        assert status2 == 404 and b"TOP-SECRET" not in body2
+
+    def test_head_static(self, env: _Env) -> None:
+        status, headers, body = env.fetch("/assets/plain.css", method="HEAD")
+        assert status == 200
+        assert body == b""
+        assert headers["content-length"] == "3"
+
+
+# ---------------------------------------------------------------------------
+# path traversal
+# ---------------------------------------------------------------------------
+#: Path-traversal corpus: literal, single- and double-encoded, backslash,
+#: mixed, and traversal smuggled through the proxied /api prefix.
+TRAVERSAL_VECTORS = [
+    "/..",
+    "/../outside-secret.txt",
+    "/..%2f..%2foutside-secret.txt",
+    "/%2e%2e/%2e%2e/outside-secret.txt",
+    "/%252e%252e/outside-secret.txt",  # double-encoded
+    "/assets/..%2f..%2foutside-secret.txt",
+    "/assets/..\\..\\outside-secret.txt",
+    "/assets/./../../outside-secret.txt",
+    "/api/../../outside-secret.txt",  # traversal through the proxy path too
+]
+
+
+class TestTraversal:
+    @pytest.mark.parametrize("vector", TRAVERSAL_VECTORS)
+    def test_traversal_never_leaks_dist(self, env: _Env, vector: str) -> None:
+        status, _headers, body = env.fetch(vector, headers={"Accept": "text/html"})
+        assert status in (400, 404), vector
+        assert b"TOP-SECRET-OUTSIDE-DIST" not in body
+        # and the proxy must NOT have been asked to forward it
+        assert all("outside-secret" not in r["path"] for r in env.requests)
+
+    def test_api_traversal_is_not_proxied(self, env: _Env) -> None:
+        status, _h, body = env.fetch("/api/..%2fmanagement")
+        assert status in (400, 404)
+        assert all(
+            "..%2f" not in r["path"] and ".." not in urlparse(r["path"]).path for r in env.requests
+        )
+
+    def test_resolve_under_dist_pure_unit(self, tmp_path: Path) -> None:
+        dist = _make_dist(tmp_path)
+        handler_cls = type("T", (alt.AltUIRequestHandler,), {})
+        handler_cls.dist_root = dist.resolve()
+        self_ = handler_cls.__new__(handler_cls)
+        assert self_._resolve_under_dist("index.html") == (dist / "index.html").resolve()
+        assert self_._resolve_under_dist("../outside-secret.txt") is None
+        assert self_._resolve_under_dist("assets/../../outside-secret.txt") is None
+        assert self_._resolve_under_dist("assets") is None  # never a directory
+        assert self_._resolve_under_dist("missing.js") is None
+
+    def test_path_clean_guard_pure_unit(self) -> None:
+        clean = ["/", "/alt", "/assets/a.js", "/positions", "/api/status", "/a%20b"]
+        dirty = ["/..", "/a/..b/..", "/%2e%2e/x", "/%252e%252e/x", "/a\\b", "/x\x00y", ""]
+        for p in clean:
+            assert alt.AltUIRequestHandler._path_is_clean(p), p
+        for p in dirty:
+            assert not alt.AltUIRequestHandler._path_is_clean(p), p
+
+
+# ---------------------------------------------------------------------------
+# reverse proxy
+# ---------------------------------------------------------------------------
+class TestProxy:
+    def test_get_token_header_passthrough(self, env: _Env) -> None:
+        status, headers, body = env.fetch(
+            "/api/status",
+            headers={"Authorization": f"Bearer {TOKEN}", "Accept": "application/json"},
+        )
+        assert status == 200
+        payload = json.loads(body)
+        assert payload["auth"] == f"Bearer {TOKEN}"
+        assert headers["content-type"].startswith("application/json")
+        # content-length corrected to the real relayed body length
+        assert int(headers["content-length"]) == len(body)
+        assert "transfer-encoding" not in headers
+
+    def test_cookie_and_x_nse_token_passthrough(self, env: _Env) -> None:
+        status, _h, body = env.fetch(
+            "/api/status",
+            headers={"Cookie": f"nse_web_auth={TOKEN}", "X-NSE-Token": TOKEN},
+        )
+        assert status == 200
+        payload = json.loads(body)
+        assert payload["cookie"] == f"nse_web_auth={TOKEN}"
+        assert payload["x_nse_token"] == TOKEN
+
+    def test_non_allowlisted_headers_dropped(self, env: _Env) -> None:
+        env.fetch("/api/status", headers={"User-Agent": "probe-ua", "X-Evil": "drop-me"})
+        seen = env.requests[-1]["headers"]
+        assert seen.get("x-evil") is None
+        assert seen.get("user-agent") is None
+        assert seen.get("host")  # corrected Host of the backend
+        assert seen.get("x-request-id", "").startswith("req_")
+
+    def test_query_string_forwarded(self, env: _Env) -> None:
+        status, _h, body = env.fetch("/api/status?since=12&live=1")
+        assert status == 200
+        assert json.loads(body)["query"] == "since=12&live=1"
+
+    def test_request_id_echo_and_forward(self, env: _Env) -> None:
+        status, headers, body = env.fetch(
+            "/api/status", headers={"X-Request-ID": "req_browser_supplied"}
+        )
+        assert status == 200
+        assert headers["x-request-id"] == "req_browser_supplied"
+        assert json.loads(body)["request_id"] == "req_browser_supplied"
+
+    def test_post_body_forwarded_with_content_type(self, env: _Env) -> None:
+        payload = json.dumps({"active": True}).encode()
+        status, _h, body = env.fetch(
+            "/api/engine/toggle",
+            headers={"Content-Type": "application/json"},
+            method="POST",
+            data=payload,
+        )
+        assert status == 200
+        assert json.loads(body)["got"] == payload.decode()
+        rec = env.requests[-1]
+        assert rec["headers"].get("content-length") == str(len(payload))
+
+    def test_upstream_401_relays_verbatim(self, env: _Env) -> None:
+        resp = env.http("/api/private")
+        assert resp.code == 401  # type: ignore[union-attr]
+        assert resp.headers.get("WWW-Authenticate") == "Bearer"  # type: ignore[union-attr]
+        data = json.loads(resp.read())  # type: ignore[union-attr]
+        assert data["error"]["code"] == "UNAUTHORIZED"
+
+    def test_chunked_upstream_reeframed_with_content_length(self, env: _Env) -> None:
+        status, headers, body = env.fetch("/api/chunked-json")
+        assert status == 200
+        assert json.loads(body) == {"chunked": True}
+        assert headers.get("transfer-encoding") is None
+        assert int(headers["content-length"]) == len(body)
+
+    def test_api_never_served_from_disk_or_cache(self, env: _Env) -> None:
+        # dist/api/status EXISTS on disk, but /api/status must always go
+        # upstream — even for a text/html Accept (no SPA fallback on API).
+        status, _h, body = env.fetch("/api/status", headers={"Accept": "text/html"})
+        assert status == 200
+        assert b"FROM_DISK" not in body
+        assert b"NSE Alt" not in body
+
+    def test_oversized_body_rejected_without_reading(self, env: _Env) -> None:
+        req = (
+            b"POST /api/engine/toggle HTTP/1.1\r\n"
+            + f"Host: {env.base.split('://')[1]}\r\n".encode()
+            + b"Content-Type: application/json\r\n"
+            + b"Content-Length: 5000000\r\n\r\n"
+        )
+        # read to EOF: the host answers 413 WITHOUT consuming the 5 MB body
+        # and closes the connection (that is the anti-DoS point).
+        raw = env.raw(req, read_until_close=True)
+        head = raw.split(b"\r\n", 1)[0]
+        assert b"413" in head
+        assert b"PAYLOAD_TOO_LARGE" in raw
+
+    def test_chunked_upload_rejected(self, env: _Env) -> None:
+        raw = env.raw(
+            b"POST /api/engine/toggle HTTP/1.1\r\n"
+            b"Host: x\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n"
+        )
+        assert b" 400 " in raw.split(b"\r\n", 1)[0]
+
+
+# ---------------------------------------------------------------------------
+# SSE passthrough
+# ---------------------------------------------------------------------------
+class TestSSEPassthrough:
+    def _stream(self, env: _Env, frames: int, gap: float, close_after: int | None = None):
+        """Read the proxied stream at raw-socket speed.
+
+        Returns (arrival_times_per_recv, assembled_bytes). ``close_after``
+        hangs up (closes the socket) after that many recv()s — used to prove
+        the upstream connection is torn down with the client.
+        """
+        hostport = env.base.split("://", 1)[1]
+        host, port = hostport.rsplit(":", 1)
+        sock = socket.create_connection((host, int(port)), timeout=20)
+        arrivals: list[float] = []
+        buf = b""
+        try:
+            req = (
+                f"GET /api/ticks/stream?frames={frames}&gap={gap:.2f} HTTP/1.1\r\n"
+                f"Host: {hostport}\r\n"
+                f"Accept: text/event-stream\r\n\r\n"
+            )
+            sock.sendall(req.encode("ascii"))
+            t0 = time.monotonic()
+            while True:
+                if close_after is not None and len(arrivals) >= close_after:
+                    break
+                try:
+                    part = sock.recv(65536)
+                except OSError:
+                    break
+                if not part:
+                    break  # upstream stream finished -> proxy closed the wire
+                arrivals.append(time.monotonic() - t0)
+                buf += part
+        finally:
+            sock.close()
+        return arrivals, buf
+
+    def test_client_disconnect_closes_upstream(self, env: _Env) -> None:
+        # 60 frames x 0.25s = 15s of runway; hang up after two recv()s and the
+        # stub must see its upstream connection die well before then (the
+        # proxy relays, then tears the upstream down with the client).
+        arrivals, _buf = self._stream(env, frames=60, gap=0.25, close_after=2)
+        assert arrivals, "expected at least one proxied frame"
+        assert env.stub.disconnect_seen.wait(10.0), (  # type: ignore[attr-defined]
+            "upstream connection must be closed after client disconnect"
+        )
+
+    def test_headers_relayed_hop_by_hop_stripped(self, env: _Env) -> None:
+        _arrivals, buf = self._stream(env, frames=1, gap=0.05)
+        head = buf.split(b"\r\n\r\n", 1)[0].lower()
+        assert b"200 ok" in head.split(b"\r\n", 1)[0]
+        assert b"content-type: text/event-stream" in head
+        assert b"transfer-encoding" not in head  # stripped + re-framed
+        assert b"connection: close" in head
+        assert b"x-request-id: req_" in head
+        assert b"x-accel-buffering: no" in head
+
+    def test_frames_arrive_unbuffered_per_chunk(self, env: _Env) -> None:
+        """The proof of TRUE passthrough: the upstream spaces frames 0.3s
+        apart. A buffering relay delivers the whole body in ONE recv at the
+        end; an unbuffered relay produces one recv per frame with the same
+        cadence. We assert both the recv count and the time spread."""
+        frames, gap = 4, 0.30
+        arrivals, buf = self._stream(env, frames=frames, gap=gap)
+        assert buf.count(b"event: tick") == frames
+        assert b'"state_version": 0' in buf and b'"state_version": 3' in buf
+        # chunk boundaries survived: one recv per upstream frame (the header
+        # block may merge with frame 0 — nothing beyond that is aggregated):
+        assert len(arrivals) >= frames, arrivals
+        # spread across the stream matches the upstream cadence, NOT a
+        # single end-of-stream dump: first->last >= 2 frame gaps.
+        spread = arrivals[-1] - arrivals[0]
+        assert spread >= 2 * gap, (arrivals, spread)
+        # and the first bytes were delivered long before the stream ended
+        assert arrivals[0] < gap, arrivals
+
+
+# ---------------------------------------------------------------------------
+# fail-closed when the backend is down
+# ---------------------------------------------------------------------------
+class TestFailClosed:
+    def test_502_envelope_backend_down(self, tmp_path: Path) -> None:
+        # a port nobody listens on (bind-then-close gives a refused port)
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        dead_port = probe.getsockname()[1]
+        probe.close()
+        dist = _make_dist(tmp_path)
+        server = alt.build_server(dist, alt.BackendTarget("127.0.0.1", dead_port), ("127.0.0.1", 0))
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        env = _Env(f"http://127.0.0.1:{server.server_address[1]}", None, server)  # type: ignore[arg-type]
+        try:
+            for path in ("/api/status", "/health", "/healthz"):
+                resp = env.http(path)
+                assert resp.status == 502, path
+                body = resp.read()
+                payload = json.loads(body)
+                assert payload["error"]["code"] == "BACKEND_UNREACHABLE"
+                assert payload["error"]["request_id"].startswith("req_")
+                assert payload["available"] is False and payload["success"] is False
+                assert resp.headers.get("content-type", "").startswith("application/json")
+                assert resp.headers.get("cache-control") == "no-store"
+                assert int(resp.headers["content-length"]) == len(body)
+                # fail-closed: NOT the SPA fallback, NOT the dist decoy file
+                assert b"FROM_DISK" not in body and b"NSE Alt" not in body
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_html_accept_still_fails_closed(self, tmp_path: Path) -> None:
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        dead_port = probe.getsockname()[1]
+        probe.close()
+        dist = _make_dist(tmp_path)
+        server = alt.build_server(dist, alt.BackendTarget("127.0.0.1", dead_port), ("127.0.0.1", 0))
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        env = _Env(f"http://127.0.0.1:{server.server_address[1]}", None, server)  # type: ignore[arg-type]
+        try:
+            resp = env.http("/api/status", headers={"Accept": "text/html"})
+            assert resp.status == 502
+            assert b"NSE Alt" not in resp.read()
+        finally:
+            server.shutdown()
+            server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# logging redaction
+# ---------------------------------------------------------------------------
+class TestLogRedaction:
+    def test_credentials_never_logged(self, env: _Env, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.INFO, logger="nse.alt_ui"):
+            # header credential
+            env.fetch("/api/status", headers={"Authorization": f"Bearer {BEARER}"})
+            # cookie credential
+            env.fetch("/api/status", headers={"Cookie": f"nse_web_auth={TOKEN}"})
+            # query-param credential (SSE transport) — forwarded upstream, redacted in logs
+            env.fetch("/api/status?token=***")
+        text = caplog.text
+        assert BEARER not in text
+        assert TOKEN not in text
+        assert "query-param-secret" not in text
+        assert "[REDACTED]" in text
+        # one access line per proxied request, carrying the correlation id
+        assert text.count("GET /api/status") >= 3
+        assert "request_id=req_" in text
+
+    def test_redactors_pure_unit(self) -> None:
+        assert alt.redact_url("/api/status?token=***") == "/api/status?token=[REDACTED]"
+        assert alt.redact_url("/x&a=1&token=***&b=2") == "/x&a=1&token=[REDACTED]&b=2"
+        assert alt.redact_url("/api/status?since=1") == "/api/status?since=1"
+        assert "super-secret" not in alt.redact_header_value("Authorization", "Bearer super-secret")
+        assert "super-secret" not in alt.redact_header_value("cookie", "session=super-secret")
+        assert alt.redact_header_value("accept", "text/html") == "text/html"
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+class TestCli:
+    def test_parse_backend_url(self) -> None:
+        b = alt.parse_backend_url("http://127.0.0.1:8080")
+        assert (b.host, b.port, b.origin) == ("127.0.0.1", 8080, "http://127.0.0.1:8080")
+        with pytest.raises(ValueError):
+            alt.parse_backend_url("https://engine.internal")
+        with pytest.raises(ValueError):
+            alt.parse_backend_url("not a url")
+
+    def test_main_defaults_loopback_and_remote_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        captured: dict = {}
+
+        class _Fake:
+            def __init__(self, addr):
+                self.server_address = addr
+                self.RequestHandlerClass = type(
+                    "H", (alt.AltUIRequestHandler,), {"dist_root": tmp_path}
+                )
+
+            def serve_forever(self):
+                captured["ran"] = True
+
+            def shutdown(self):
+                pass
+
+            def server_close(self):
+                pass
+
+        def fake_build(dist, backend, listen=("127.0.0.1", 8088)):
+            captured["listen"] = listen
+            captured["backend"] = backend
+            return _Fake(listen)
+
+        monkeypatch.setattr(alt, "build_server", fake_build)
+        rc = alt.main(["--dist", str(tmp_path)])
+        assert rc == 0 and captured["ran"]
+        assert captured["listen"] == ("127.0.0.1", 8088)
+        assert captured["backend"].origin == "http://127.0.0.1:8080"
+        assert "NON-LOCALHOST" not in capsys.readouterr().err
+
+        rc = alt.main(["--dist", str(tmp_path), "--allow-remote", "--port", "9999"])
+        assert rc == 0
+        assert captured["listen"] == ("0.0.0.0", 9999)
+        err = capsys.readouterr().err
+        assert "NON-LOCALHOST ADDRESS (0.0.0.0)" in err
+        assert "auth model" in err.lower() or "enforces NOTHING" in err
+
+    def test_main_missing_dist_is_actionable(self, tmp_path: Path) -> None:
+        rc = alt.main(["--dist", str(tmp_path / "nope")])
+        assert rc == 2
+
+
+if __name__ == "__main__":  # standalone probe (no pytest needed)
+    sys.exit(pytest.main([__file__, "-v", "-p", "no:cacheprovider"]))


### PR DESCRIPTION
BACKEND-1 lane commit 2bff06eb (tip == the whole payload: 1 commit vs main, merge-tree clean against current main).
Adds scripts/serve_alt_ui.py (loopback:8088 static host for frontend/dist with SPA fallback, /alt base-prefix strip, reverse proxy for /api|/health with header allowlist + X-Request-ID + 1MiB guard + hop-by-hop strip, TRUE SSE passthrough for /api/ticks/stream, fail-closed 502 BACKEND_UNREACHABLE envelope, traversal-refusing static serving, hashed-asset immutable caching, credential-redacted logs), scripts/README-alt-ui.md, and 39 offline tests.
Supervisor verification pre-PR: fresh worktree at branch tip, PYTHONPATH-isolated pytest tests/unit/test_alt_ui_standalone_server.py -> 39 passed (39.7s); git diff vs main = only these 3 new files; no production src touched.
Complements (does not replace) the in-process /alt mount in web/server.py - separate standalone-dev host, engine untouched.